### PR TITLE
Fix/small rewrite of Virtual boot partition

### DIFF
--- a/optiboot/bootloaders/optiboot/Makefile
+++ b/optiboot/bootloaders/optiboot/Makefile
@@ -238,7 +238,7 @@ endif
 # Virtual boot block test
 virboot8: TARGET = atmega8
 virboot8: MCU_TARGET = atmega8
-virboot8: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION'
+virboot8: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION' '-Dsave_vect_num=EE_RDY_vect_num'
 virboot8: AVR_FREQ ?= 16000000L 
 virboot8: LDSECTIONS  = -Wl,--section-start=.text=0x1c00 -Wl,--section-start=.version=0x1ffe
 virboot8: $(PROGRAM)_virboot8.hex

--- a/optiboot/bootloaders/optiboot/Makefile
+++ b/optiboot/bootloaders/optiboot/Makefile
@@ -236,6 +236,15 @@ endif
 
 # Test platforms
 # Virtual boot block test
+virboot8: TARGET = atmega8
+virboot8: MCU_TARGET = atmega8
+virboot8: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION'
+virboot8: AVR_FREQ ?= 16000000L 
+virboot8: LDSECTIONS  = -Wl,--section-start=.text=0x1c00 -Wl,--section-start=.version=0x1ffe
+virboot8: $(PROGRAM)_virboot8.hex
+virboot8: $(PROGRAM)_virboot8.lst
+
+
 virboot328: TARGET = atmega328
 virboot328: MCU_TARGET = atmega328p
 virboot328: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION'

--- a/optiboot/bootloaders/optiboot/optiboot.c
+++ b/optiboot/bootloaders/optiboot/optiboot.c
@@ -395,14 +395,22 @@ void appStart(uint8_t rstFlags) __attribute__ ((naked));
 #define rstVect1_sav (*(uint8_t*)(RAMSTART+SPM_PAGESIZE*2+5))
 #define saveVect0_sav (*(uint8_t*)(RAMSTART+SPM_PAGESIZE*2+6))
 #define saveVect1_sav (*(uint8_t*)(RAMSTART+SPM_PAGESIZE*2+7))
-// Vector to save original reset jump - SPM Ready is least probably used
+// Vector to save original reset jump:
+//   SPM Ready is least probably used, so it's default
+//   if not, use old way WDT_vect_num,
+//   or simply set custom save_vect_num in Makefile using vector name
+//   or even raw number.
+#if !defined (save_vect_num)
 #if defined (SPM_RDY_vect_num)
 #define save_vect_num (SPM_RDY_vect_num)
 #elif defined (SPM_READY_vect_num)
 #define save_vect_num (SPM_READY_vect_num)
+#elif defined (WDT_vect_num)
+#define save_vect_num (WDT_vect_num)
 #else
-#error Cant find SPM interrupt vector for this CPU
+#error Cant find SPM or WDT interrupt vector for this CPU
 #endif
+#endif //save_vect_num
 // check if it's on the same page (code assumes that)
 #if (SPM_PAGESIZE <= save_vect_num)
 #error Save vector not in the same page as reset!


### PR DESCRIPTION
* Changed interrupt vector to save original jump. Now uses SPM_Ready
  instead of watchdog's. It's also easier to add another vector if this is unavailable
  (see lines 399-405)
* Rewrite/fix 'rjmp' part to use and calculate correctly on all 12 bits
  of address.
* Added 'virboot8' test target to Makefile with Virtboot for Atmega8.