### PR TITLE
Added possibility to write FLASH memory from application

### DIFF
--- a/optiboot/bootloaders/optiboot/optiboot.c
+++ b/optiboot/bootloaders/optiboot/optiboot.c
@@ -347,6 +347,7 @@ typedef uint8_t pagelen_t;
  * supress some compile-time options we want.)
  */
 
+void pre_main(void) __attribute__ ((naked)) __attribute__ ((section (".init8")));
 int main(void) __attribute__ ((OS_main)) __attribute__ ((section (".init9")));
 
 void __attribute__((noinline)) putch(char);
@@ -361,6 +362,7 @@ static inline void writebuffer(int8_t memtype, uint8_t *mybuff,
 			       uint16_t address, pagelen_t len);
 static inline void read_mem(uint8_t memtype,
 			    uint16_t address, pagelen_t len);
+static void __attribute((noinline)) do_spm(uint16_t address, uint8_t command, uint16_t data);
 
 #ifdef SOFT_UART
 void uartDelay() __attribute__ ((naked));
@@ -435,6 +437,18 @@ void appStart(uint8_t rstFlags) __attribute__ ((naked));
 #else
 #define appstart_vec (0)
 #endif // VIRTUAL_BOOT_PARTITION
+
+/* everything that needs to run VERY early */
+void pre_main(void) {
+  // Allow convinient way of calling do_spm function - jump table,
+  //   so entry to this function will always be here, indepedent of compilation,
+  //   features etc
+  asm volatile (
+    "	rjmp	1f\n"
+    "	rjmp	do_spm\n"
+    "1:\n"
+  );
+}
 
 
 /* main program starts here */
@@ -885,8 +899,7 @@ static inline void writebuffer(int8_t memtype, uint8_t *mybuff,
 	     * the serial link, but the performance improvement was slight,
 	     * and we needed the space back.
 	     */
-	    __boot_page_erase_short((uint16_t)(void*)address);
-	    boot_spm_busy_wait();
+	    do_spm((uint16_t)(void*)address,__BOOT_PAGE_ERASE,0);
 
 	    /*
 	     * Copy data from the buffer into the flash write buffer.
@@ -895,19 +908,14 @@ static inline void writebuffer(int8_t memtype, uint8_t *mybuff,
 		uint16_t a;
 		a = *bufPtr++;
 		a |= (*bufPtr++) << 8;
-		__boot_page_fill_short((uint16_t)(void*)addrPtr,a);
+		do_spm((uint16_t)(void*)addrPtr,__BOOT_PAGE_FILL,a);
 		addrPtr += 2;
 	    } while (len -= 2);
 
 	    /*
 	     * Actually Write the buffer to flash (and wait for it to finish.)
 	     */
-	    __boot_page_write_short((uint16_t)(void*)address);
-	    boot_spm_busy_wait();
-#if defined(RWWSRE)
-	    // Reenable read access to flash
-	    boot_rww_enable();
-#endif
+	    do_spm((uint16_t)(void*)address,__BOOT_PAGE_WRITE,0);
 	} // default block
 	break;
     } // switch
@@ -951,4 +959,51 @@ static inline void read_mem(uint8_t memtype, uint16_t address, pagelen_t length)
 	} while (--length);
 	break;
     } // switch
+}
+
+/*
+ * Separate function for doing spm stuff
+ * It's needed for application to do SPM, as SPM instruction works only
+ * from bootloader.
+ *
+ * How it works:
+ * - do SPM
+ * - wait for SPM to complete
+ * - if chip have RWW/NRWW sections it does additionaly:
+ *   - if command is WRITE or ERASE, AND data=0 then reenable RWW section
+ *
+ * In short:
+ * If you play erase-fill-write, just set data to 0 in ERASE and WRITE
+ * If you are brave, you have your code just below bootloader in NRWW section
+ *   you could do fill-erase-write sequence with data!=0 in ERASE and
+ *   data=0 in WRITE
+ */
+static void do_spm(uint16_t address, uint8_t command, uint16_t data) {
+    // Do spm stuff
+    asm volatile (
+	"    movw  r0, %3\n"
+        "    out %0, %1\n"
+        "    spm\n"
+        "    clr  r1\n"
+        :
+        : "i" (_SFR_IO_ADDR(__SPM_REG)),
+          "r" ((uint8_t)command),
+          "z" ((uint16_t)address),
+          "r" ((uint16_t)data)
+        : "r0"
+    );
+
+    // wait for spm to complete
+    //   it doesn't have much sense for __BOOT_PAGE_FILL,
+    //   but it doesn't hurt and saves some bytes on 'if'
+    boot_spm_busy_wait();
+#if defined(RWWSRE)
+    // this 'if' condition should be: (command == __BOOT_PAGE_WRITE || command == __BOOT_PAGE_ERASE)...
+    // but it's tweaked a little assuming that in every command we are interested in here, there
+    // must be also SELFPRGEN set. If we skip checking this bit, we save here 4B
+    if ((command & (_BV(PGWRT)|_BV(PGERS))) && (data == 0) ) {
+      // Reenable read access to flash
+      boot_rww_enable();
+    }
+#endif
 }

--- a/optiboot/bootloaders/optiboot/optiboot.c
+++ b/optiboot/bootloaders/optiboot/optiboot.c
@@ -362,7 +362,7 @@ static inline void writebuffer(int8_t memtype, uint8_t *mybuff,
 			       uint16_t address, pagelen_t len);
 static inline void read_mem(uint8_t memtype,
 			    uint16_t address, pagelen_t len);
-static void __attribute((noinline)) do_spm(uint16_t address, uint8_t command, uint16_t data);
+static void __attribute__((noinline)) do_spm(uint16_t address, uint8_t command, uint16_t data);
 
 #ifdef SOFT_UART
 void uartDelay() __attribute__ ((naked));
@@ -440,7 +440,7 @@ void appStart(uint8_t rstFlags) __attribute__ ((naked));
 
 /* everything that needs to run VERY early */
 void pre_main(void) {
-  // Allow convinient way of calling do_spm function - jump table,
+  // Allow convenient way of calling do_spm function - jump table,
   //   so entry to this function will always be here, indepedent of compilation,
   //   features etc
   asm volatile (

--- a/optiboot/examples/flash_program/flash_program.ino
+++ b/optiboot/examples/flash_program/flash_program.ino
@@ -75,7 +75,7 @@ void setup() {
   // Erasing FLASH page
   Serial.println("Erasing buffer");
   delay(100); // wait for sending all text via serial
-  optiboot_page_erase((uint16_t)(void*) &flash_buffer[0]);
+  optiboot_page_erase((optiboot_addr_t)(void*) &flash_buffer[0]);
 
   // Copy ram buffer to temporary flash buffer
   Serial.println("Writing to temporary flash buffer");
@@ -85,14 +85,14 @@ void setup() {
       w = ram_buffer[i];
     } else {
       w += (ram_buffer[i] << 8);
-      optiboot_page_fill((uint16_t)(void*) &flash_buffer[i],w);
+      optiboot_page_fill((optiboot_addr_t)(void*) &flash_buffer[i],w);
     }
   }
   
   // Writing temporary buffer to FLASH
   Serial.println("Writing buffer to flash");
   delay(100); // wait for sending all text via serial
-  optiboot_page_write((uint16_t)(void*) &flash_buffer[0]);
+  optiboot_page_write((optiboot_addr_t)(void*) &flash_buffer[0]);
 
   Serial.println("Write done, thank you!");
   Serial.println("Now you can reset or power cycle board and check for new contents!");

--- a/optiboot/examples/flash_program/flash_program.ino
+++ b/optiboot/examples/flash_program/flash_program.ino
@@ -1,0 +1,104 @@
+/* flash_program
+ *
+ * June 2015 by Marek Wodzinski, https://github.com/majekw
+ * Released to public domain
+ *
+ * This is example how to use optiboot.h together with Optiboot
+ * bootloader to write to FLASH memory by application code.
+ *
+ * IMPORTANT THINGS:
+ * - buffer must be page aligned (see declaration of flash_buffer)
+ * - interrupts must be disabled during spm
+ * - writing to EEPROM destroys temporary buffer
+ * - you can write only once into one location of temporary buffer
+ * - only safely and always working sequence is erase-fill-write
+ * - if you want to do fill-erase-write, you must put code in NRWW
+ *     and pass data!=0 for erase. It's not easy, but possible.
+ *
+ * WRITE SEQUENCE - option 1 (used in this example)
+ * 1. Erase page by optiboot_page_erase
+ * 2. Write contents of page into temporary buffer by optiboot_page_fill
+ * 3. Write temporary buffer to FLASH by optiboot_page_write
+ *
+ * WRITE SEQUENCE - option 2 (works only for code in NRWW)
+ * 1. Write contents of page into temporary buffer by optiboot_page_fill
+ * 2. Erase page by optiboot_page_erase (set data to NOT zero)
+ * 3. Write temporary buffer to FLASH by optiboot_page_write
+ */
+
+#include "optiboot.h"
+#include <avr/pgmspace.h>
+
+const char flash_buffer[SPM_PAGESIZE] __attribute__ (( aligned(SPM_PAGESIZE) )) PROGMEM= {
+  "0123456789ABCDEFGHIJKLMNOPQRSTUVW"
+};
+
+void setup() {
+  int i;
+  uint8_t c;
+  uint16_t w;
+  uint8_t ram_buffer[SPM_PAGESIZE];
+
+  // Init serial
+  Serial.begin(9600);
+  
+  // Print current flash buffer content
+  Serial.println("Current flash contents:");
+  for (i=0;i<SPM_PAGESIZE;i++) {
+    c = pgm_read_byte(&flash_buffer[i]);
+    if (c!=0 && c!=255) {
+      Serial.write(c);
+    } else {
+      Serial.print(".");
+    }
+  }
+  
+  // Print prompt to enter some new characters to write to flash
+  Serial.println();
+  Serial.print("Type ");
+  Serial.print(SPM_PAGESIZE);
+  Serial.println(" characters to store in flash:");
+
+  // Get characters from serial and put into ram buffer
+  i=0;
+  while (i<SPM_PAGESIZE) {
+    if (Serial.available()>0) {
+      c = Serial.read(); // read character from serial
+      Serial.write(c); // echo character back
+      ram_buffer[i] = c;
+      i++;
+    }
+  }
+  Serial.println("\nAll chars received");
+  delay(100); // wait for sending all text via serial
+  
+  // Erasing FLASH page
+  Serial.println("Erasing buffer");
+  delay(100); // wait for sending all text via serial
+  optiboot_page_erase((uint16_t)(void*) &flash_buffer[0]);
+
+  // Copy ram buffer to temporary flash buffer
+  Serial.println("Writing to temporary flash buffer");
+  delay(100); // wait for sending all text via serial
+  for (i=0;i<SPM_PAGESIZE;i++) {
+    if (i % 2 == 0) { // we must write WORDs
+      w = ram_buffer[i];
+    } else {
+      w += (ram_buffer[i] << 8);
+      optiboot_page_fill((uint16_t)(void*) &flash_buffer[i],w);
+    }
+  }
+  
+  // Writing temporary buffer to FLASH
+  Serial.println("Writing buffer to flash");
+  delay(100); // wait for sending all text via serial
+  optiboot_page_write((uint16_t)(void*) &flash_buffer[0]);
+
+  Serial.println("Write done, thank you!");
+  Serial.println("Now you can reset or power cycle board and check for new contents!");
+}
+
+void loop() {
+  // no code here
+}
+

--- a/optiboot/examples/flash_program/optiboot.h
+++ b/optiboot/examples/flash_program/optiboot.h
@@ -65,12 +65,23 @@
  *
  */
 
-// 'typedef' (in following line) and 'const' (few lines below) are a way to define external function at some arbitrary address
+/*
+ * This 'typedef' (in following line) and 'const' (few lines below) are a way to define external function at some arbitrary address
+ */
 typedef void (*do_spm_t)(uint16_t address, uint8_t command, uint16_t data);
 
 /*
+ * Devices with 64KB of flash or more have larger bootloader area (1KB) (they are BIGBOOT targets),
+ * so entry address in these chips is different from smaller ones.
+ */
+#if FLASHEND > 65534
+  const do_spm_t do_spm = (do_spm_t)((FLASHEND-1023+2)>>1);
+#else
+  const do_spm_t do_spm = (do_spm_t)((FLASHEND-511+2)>>1);
+#endif
+
+/*
  * Devices with more than 64KB of flash:
- * - have larger bootloader area (1KB) (they are BIGBOOT targets)
  * - have RAMPZ register :-) 
  * - need larger variable to hold address (pgmspace.h uses uint32_t)
  * 
@@ -79,10 +90,8 @@ typedef void (*do_spm_t)(uint16_t address, uint8_t command, uint16_t data);
  */
 #ifdef RAMPZ
   typedef uint32_t optiboot_addr_t;
-  const do_spm_t do_spm = (do_spm_t)((FLASHEND-1023+2)>>1);
 #else
   typedef uint16_t optiboot_addr_t;
-  const do_spm_t do_spm = (do_spm_t)((FLASHEND-511+2)>>1);
 #endif
 
 /*

--- a/optiboot/examples/flash_program/optiboot.h
+++ b/optiboot/examples/flash_program/optiboot.h
@@ -1,0 +1,109 @@
+
+/* Optiboot 'header' file.
+ * 
+ * June 2015 by Marek Wodzinski, https://github.com/majekw
+ * Released to public domain
+ * 
+ * This header file gives possibility to use SPM instruction
+ * from Optiboot bootloader memory.
+ *
+ * There are 3 convenient functions available here:
+ *  optiboot_page_erase - to erase FLASH page
+ *  optiboot_page_fill - to put words into temporary buffer
+ *  optiboot_page_write - to write contents of temporary buffer into FLASH
+ *
+ * For some hardcore users, you could use 'do_spm' as raw entry to
+ * bootloader spm function.
+ */
+
+#ifndef _OPTIBOOT_H_
+#define _OPTIBOOT_H_  1
+
+#include <avr/boot.h>
+
+/* 
+ * Main 'magic' function - enter to bootloader do_spm function
+ *
+ * address - address to write (in bytes) but must be even number
+ * command - one of __BOOT_PAGE_WRITE, __BOOT_PAGE_ERASE or __BOOT_PAGE_FILL
+ * data - data to write in __BOOT_PAGE_FILL. In __BOOT_PAGE_ERASE or 
+ *          __BOOT_PAGE_WRITE it control if boot_rww_enable is run
+ *         (0 = run, !0 = skip running boot_rww_enable)
+ *
+ *
+ * Contents of bootloader's do_spm function, just for reference:
+ *
+ * static void do_spm(uint16_t address, uint8_t command, uint16_t data) {
+ *     // Do spm stuff
+ *     asm volatile (
+ * 	 "    movw  r0, %3\n"
+ *       "    out %0, %1\n"
+ *       "    spm\n"
+ *       "    clr  r1\n"
+ *       :
+ *       : "i" (_SFR_IO_ADDR(__SPM_REG)),
+ *         "r" ((uint8_t)command),
+ *         "z" ((uint16_t)address),
+ *         "r" ((uint16_t)data)
+ *       : "r0"
+ *     );
+ * 
+ *     // wait for spm to complete
+ *     //   it doesn't have much sense for __BOOT_PAGE_FILL,
+ *     //   but it doesn't hurt and saves some bytes on 'if'
+ *     boot_spm_busy_wait();
+ * #if defined(RWWSRE)
+ *     // this 'if' condition should be: (command == __BOOT_PAGE_WRITE || command == __BOOT_PAGE_ERASE)...
+ *     // but it's tweaked a little assuming that in every command we are interested in here, there
+ *     // must be also SELFPRGEN set. If we skip checking this bit, we save here 4B
+ *     if ((command & (_BV(PGWRT)|_BV(PGERS))) && (data == 0) ) {
+ *       // Reenable read access to flash
+ *       boot_rww_enable();
+ *     }
+ * #endif
+ * }
+ *
+ */
+typedef void (*do_spm_t)(uint16_t address, uint8_t command, uint16_t data);
+const do_spm_t do_spm = (do_spm_t)((FLASHEND-511+2)>>1);
+
+
+/*
+ * The same as do_spm but with disable/restore interrupts state
+ * required to succesfull SPM execution
+ */
+void do_spm_cli(uint16_t address, uint8_t command, uint16_t data) {
+  uint8_t sreg_save;
+
+  sreg_save = SREG;  // save old SREG value
+  asm volatile("cli");  // disable interrupts
+  do_spm(address,command,data);
+  SREG=sreg_save; // restore last interrupts state
+}
+
+
+/*
+ * Erase page in FLASH
+ */
+void optiboot_page_erase(uint16_t address) {
+  do_spm_cli(address,__BOOT_PAGE_ERASE,0);
+}
+
+
+/*
+ * Write word into temporary buffer
+ */
+void optiboot_page_fill(uint16_t address, uint16_t data) {
+  do_spm_cli(address,__BOOT_PAGE_FILL,data);
+}
+
+
+/*
+ * Write temporary buffer into FLASH
+ */
+void optiboot_page_write(uint16_t address) {
+  do_spm_cli(address,__BOOT_PAGE_WRITE,0);
+}
+
+#endif /* _OPTIBOOT_H_ */
+

--- a/optiboot/examples/flash_program/optiboot.h
+++ b/optiboot/examples/flash_program/optiboot.h
@@ -64,28 +64,53 @@
  * }
  *
  */
-typedef void (*do_spm_t)(uint16_t address, uint8_t command, uint16_t data);
-const do_spm_t do_spm = (do_spm_t)((FLASHEND-511+2)>>1);
 
+// 'typedef' (in following line) and 'const' (few lines below) are a way to define external function at some arbitrary address
+typedef void (*do_spm_t)(uint16_t address, uint8_t command, uint16_t data);
+
+/*
+ * Devices with more than 64KB of flash:
+ * - have larger bootloader area (1KB) (they are BIGBOOT targets)
+ * - have RAMPZ register :-) 
+ * - need larger variable to hold address (pgmspace.h uses uint32_t)
+ * 
+ * To not do many ifdefs and don't confuse users I declared new 'always valid'
+ * type to declare address: optiboot_addr_t.
+ */
+#ifdef RAMPZ
+  typedef uint32_t optiboot_addr_t;
+  const do_spm_t do_spm = (do_spm_t)((FLASHEND-1023+2)>>1);
+#else
+  typedef uint16_t optiboot_addr_t;
+  const do_spm_t do_spm = (do_spm_t)((FLASHEND-511+2)>>1);
+#endif
 
 /*
  * The same as do_spm but with disable/restore interrupts state
  * required to succesfull SPM execution
+ * 
+ * On devices with more than 64kB flash, 16 bit address is not enough,
+ * so there is also RAMPZ used in that case.
  */
-void do_spm_cli(uint16_t address, uint8_t command, uint16_t data) {
+
+void do_spm_cli(optiboot_addr_t address, uint8_t command, uint16_t data) {
   uint8_t sreg_save;
 
   sreg_save = SREG;  // save old SREG value
   asm volatile("cli");  // disable interrupts
-  do_spm(address,command,data);
+  #ifdef RAMPZ
+    RAMPZ=(address>>16) & 0xff;  // address bits 23-16 goes to RAMPZ
+    do_spm((address & 0xffff),command,data); // do_spm accepts only lower 16 bits of address
+  #else
+    do_spm(address,command,data);  // 16 bit address - no problems to pass directly
+  #endif
   SREG=sreg_save; // restore last interrupts state
 }
-
 
 /*
  * Erase page in FLASH
  */
-void optiboot_page_erase(uint16_t address) {
+void optiboot_page_erase(optiboot_addr_t address) {
   do_spm_cli(address,__BOOT_PAGE_ERASE,0);
 }
 
@@ -93,7 +118,7 @@ void optiboot_page_erase(uint16_t address) {
 /*
  * Write word into temporary buffer
  */
-void optiboot_page_fill(uint16_t address, uint16_t data) {
+void optiboot_page_fill(optiboot_addr_t address, uint16_t data) {
   do_spm_cli(address,__BOOT_PAGE_FILL,data);
 }
 
@@ -101,7 +126,7 @@ void optiboot_page_fill(uint16_t address, uint16_t data) {
 /*
  * Write temporary buffer into FLASH
  */
-void optiboot_page_write(uint16_t address) {
+void optiboot_page_write(optiboot_addr_t address) {
   do_spm_cli(address,__BOOT_PAGE_WRITE,0);
 }
 


### PR DESCRIPTION
I moved all SPM instructions to separate function, so it could be called by application.
Now writing to flash is possible :-)

Working example provided.
I tested it on Atmega8, Atmega168 and Atmega328.

It adds 6 bytes to bootloader size, but I think that this feature is worth it :-)

Resolves #99, it could partially resolve #52 (original idea in #52 was only to allow jump to bootloader, but later it drifted towards #99).
