### PR TITLE
Fix compilation of Attiny84 and some ld crashes on older avr-gcc

### DIFF
--- a/optiboot/bootloaders/optiboot/Makefile
+++ b/optiboot/bootloaders/optiboot/Makefile
@@ -320,7 +320,7 @@ atmega8: TARGET = atmega8
 atmega8: MCU_TARGET = atmega8
 atmega8: CFLAGS += $(COMMON_OPTIONS)
 atmega8: AVR_FREQ ?= 16000000L 
-atmega8: LDSECTIONS  = -Wl,--section-start=.text=0x1e00 -Wl,--section-start=.version=0x1ffe
+atmega8: LDSECTIONS  = -Wl,--section-start=.text=0x1e00 -Wl,--section-start=.version=0x1ffe -Wl,--gc-sections -Wl,--undefined=optiboot_version
 atmega8: $(PROGRAM)_atmega8.hex
 atmega8: $(PROGRAM)_atmega8.lst
 

--- a/optiboot/bootloaders/optiboot/Makefile.extras
+++ b/optiboot/bootloaders/optiboot/Makefile.extras
@@ -92,7 +92,7 @@ atmega32_isp: isp
 attiny84: TARGET = attiny84
 attiny84: MCU_TARGET = attiny84
 attiny84: CFLAGS += $(COMMON_OPTIONS) -DSOFT_UART -DVIRTUAL_BOOT_PARTITION -Dsave_vect_num=4
-attiny84: LDSECTIONS = -Wl,--section-start=.text=0x1c00 -Wl,--section-start=.version=0x1ffe -Wl,--gc-sections -Wl,--undefined=optiboot_version
+attiny84: LDSECTIONS = -Wl,--section-start=.text=0x1d00 -Wl,--section-start=.version=0x1ffe -Wl,--gc-sections -Wl,--undefined=optiboot_version
 attiny84: $(PROGRAM)_attiny84.hex
 attiny84: $(PROGRAM)_attiny84.lst
 

--- a/optiboot/bootloaders/optiboot/Makefile.extras
+++ b/optiboot/bootloaders/optiboot/Makefile.extras
@@ -18,7 +18,7 @@ atmega88: TARGET = atmega88
 atmega88: MCU_TARGET = atmega88
 atmega88: CFLAGS += $(COMMON_OPTIONS)
 atmega88: AVR_FREQ ?= 16000000L 
-atmega88: LDSECTIONS  = -Wl,--section-start=.text=0x1e00 -Wl,--section-start=.version=0x1ffe
+atmega88: LDSECTIONS  = -Wl,--section-start=.text=0x1e00 -Wl,--section-start=.version=0x1ffe -Wl,--gc-sections -Wl,--undefined=optiboot_version
 atmega88: $(PROGRAM)_atmega88.hex
 atmega88: $(PROGRAM)_atmega88.lst
 
@@ -91,8 +91,8 @@ atmega32_isp: isp
 #
 attiny84: TARGET = attiny84
 attiny84: MCU_TARGET = attiny84
-attiny84: CFLAGS += $(COMMON_OPTIONS) -DSOFT_UART -DVIRTUAL_BOOT_PARTITION
-attiny84: LDSECTIONS = -Wl,--section-start=.text=0x1d00 -Wl,--section-start=.version=0x1ffe
+attiny84: CFLAGS += $(COMMON_OPTIONS) -DSOFT_UART -DVIRTUAL_BOOT_PARTITION -Dsave_vect_num=4
+attiny84: LDSECTIONS = -Wl,--section-start=.text=0x1c00 -Wl,--section-start=.version=0x1ffe -Wl,--gc-sections -Wl,--undefined=optiboot_version
 attiny84: $(PROGRAM)_attiny84.hex
 attiny84: $(PROGRAM)_attiny84.lst
 


### PR DESCRIPTION
* Added override of 'save_vect_num' in Makefile on Attiny84 target as  WDT_vect_num isn't defined on old avr-gcc (shipped with Arduino 1.0.5/6). Fixes #134
* Added workaround for avr-gcc bug #6019. It should fix #88, at least it works on Linux using Arduino 1.0.5 or 1.0.6. Windows tests needed to confirm that.