### PR TITLE
Use correct category value in JSON index file

### DIFF
--- a/optiboot/package_optiboot_optiboot-additional_index.json.TEMPLATE
+++ b/optiboot/package_optiboot_optiboot-additional_index.json.TEMPLATE
@@ -23,7 +23,7 @@
           "name": "Optiboot %VERSION%",
           "architecture": "avr",
           "version": "0.%VERSION%",
-          "category": "Optiboot",
+          "category": "Contributed",
           "help": {
             "online": ""
           },


### PR DESCRIPTION
Per https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.6.x---package_index.json-format-specification:
> category: this field is reserved, a 3rd party core must set it to Contributed