### PR TITLE
Fast start/MCUSR fix

### DIFF
--- a/optiboot/bootloaders/optiboot/optiboot.c
+++ b/optiboot/bootloaders/optiboot/optiboot.c
@@ -505,7 +505,7 @@ int main(void) {
 #if !defined(__AVR_ATmega16__)
         MCUSR = ~(_BV(WDRF));  
 #else
-        MCUSR = ~(_BV(WDRF));  
+        MCUCSR = ~(_BV(WDRF));  
 #endif
       }
       appStart(ch);


### PR DESCRIPTION
Hello.

This is a fix for fast start and clearing MCUSR heavily discussed in #140 and #97. It's also related to #111.
Code is almost unmodified by @MarkG55.
I rewrote comments to explain more, and increased initial bootloader timeout from 1s to 2s as requested in few places (it helps during manual/button reset).
