### PR TITLE
Declare .init0 section as used in example sketch.

### DIFF
--- a/optiboot/examples/test_reset/test_reset.ino
+++ b/optiboot/examples/test_reset/test_reset.ino
@@ -23,6 +23,7 @@ uint8_t resetFlags __attribute__ ((section(".noinit")));
  * to the variable.  Again, avr-gcc provides special code sections for this.
  */
 void resetFlagsInit(void) __attribute__ ((naked))
+                          __attribute__ ((used))
                           __attribute__ ((section (".init0")));
 void resetFlagsInit(void)
 {


### PR DESCRIPTION
Without this attribute, the Arduino IDE may optimize away the .init0 code which retrieves optiboot's watchdog value.

Solution to #187

Tested on Arduino IDE 1.6.11.