### PR TITLE
Fixed UART 3 check

### DIFF
--- a/optiboot/bootloaders/optiboot/pin_defs.h
+++ b/optiboot/bootloaders/optiboot/pin_defs.h
@@ -61,7 +61,7 @@
 # define UART_SRL UBRR2L
 # define UART_UDR UDR2
 #elif UART == 3
-#if !defined(UDR1)
+#if !defined(UDR3)
 #error UART == 3, but no UART3 on device
 #endif
 # define UART_SRA UCSR3A


### PR DESCRIPTION
If UART 3 is selected it should be checked if UDR3 is defined and not if UDR1 is defined.