### PR TITLE
Add support for test compilation using Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 #    - ARDUINO_VERSION=1.0.6
     - ARDUINO_VERSION=1.6.9
 #    - ARDUINO_VERSION=1.6.13
-#    - ARDUINO_VERSION=1.8.3
+#    - ARDUINO_VERSION=1.8.4
   matrix:
     - OPTIBOOT_TARGET=bobuino
     - OPTIBOOT_TARGET=diecimila

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,60 @@
+language: bash
+dist: trusty
+sudo: false
+
+cache:
+  directories:
+    - $HOME/avr-tools    
+install: true
+
+env:
+  global:
+#    - ARDUINO_VERSION=1.0.6
+    - ARDUINO_VERSION=1.6.9
+#    - ARDUINO_VERSION=1.6.13
+#    - ARDUINO_VERSION=1.8.3
+  matrix:
+    - OPTIBOOT_TARGET=bobuino
+    - OPTIBOOT_TARGET=diecimila
+    - OPTIBOOT_TARGET=lilypad
+    - OPTIBOOT_TARGET=lilypad_resonator
+    - OPTIBOOT_TARGET=luminet
+    - OPTIBOOT_TARGET=mega1280
+    - OPTIBOOT_TARGET=mighty1284
+    - OPTIBOOT_TARGET=pro16
+    - OPTIBOOT_TARGET=pro20
+    - OPTIBOOT_TARGET=pro8
+    - OPTIBOOT_TARGET=sanguino
+    - OPTIBOOT_TARGET=virboot328
+    - OPTIBOOT_TARGET=virboot8
+    - OPTIBOOT_TARGET=wildfire
+    - OPTIBOOT_TARGET=wildfirev2
+    - OPTIBOOT_TARGET=wildfirev3
+    - OPTIBOOT_TARGET=xplained168pb
+    - OPTIBOOT_TARGET=xplained328p
+    - OPTIBOOT_TARGET=xplained328pb
+    - OPTIBOOT_TARGET=atmega1280
+    - OPTIBOOT_TARGET=atmega1284
+    - OPTIBOOT_TARGET=atmega1284p
+    - OPTIBOOT_TARGET=atmega16
+    - OPTIBOOT_TARGET=atmega168
+    - OPTIBOOT_TARGET=atmega168p
+    - OPTIBOOT_TARGET=atmega32
+    - OPTIBOOT_TARGET=atmega328
+    - OPTIBOOT_TARGET=atmega328_pro8
+    - OPTIBOOT_TARGET=atmega644p
+    - OPTIBOOT_TARGET=atmega8
+    - OPTIBOOT_TARGET=atmega88
+    - OPTIBOOT_TARGET=attiny84
+
+matrix:
+  allow_failures:
+    - env: OPTIBOOT_TARGET=attiny84
+
+script: scripts/travis-build.sh $ARDUINO_VERSION $OPTIBOOT_TARGET
+
+notifications:
+  email:
+    on_success: always
+    on_failure: always
+ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 #    - ARDUINO_VERSION=1.0.6
     - ARDUINO_VERSION=1.6.9
 #    - ARDUINO_VERSION=1.6.13
-#    - ARDUINO_VERSION=1.8.4
+#    - ARDUINO_VERSION=1.8.5
   matrix:
     - OPTIBOOT_TARGET=bobuino
     - OPTIBOOT_TARGET=diecimila

--- a/docs/arduino-gcc-versions.md
+++ b/docs/arduino-gcc-versions.md
@@ -1,0 +1,40 @@
+Arduino ships also avr-gcc. This is matrix of versions and changes
+based on Linux versions.
+
+
+| Arduino | avr-gcc | differences | test? |
+|---------|---------|-------------|-------|
+|<=1.0    |none?    | | |
+|1.0.1    |4.3.2    |new| |
+|1.0.2    |4.3.2    |same as 1.0.1| |
+|1.0.3    |4.3.2    |same as 1.0.1| |
+|1.0.4    |4.3.2    |same as 1.0.1| |
+|1.0.5    |4.3.2    |same as 1.0.1| |
+|1.0.6    |4.3.2    |same as 1.0.1| yes |
+|1.5      |4.3.2    |same as 1.0.1| |
+|1.5.1    |4.3.2    |same as 1.0.1| |
+|1.5.2    |4.3.2    |same as 1.0.1| |
+|1.5.3    |4.3.2    |same as 1.0.1| |
+|1.5.4    |4.3.2    |same as 1.0.1| |
+|1.5.5    |4.3.2    |same as 1.0.1| |
+|1.5.6-r2 |4.3.2    |same as 1.0.1| |
+|1.5.7    |4.8.1    |toolchains upgrade, avrdude 6.0.1avrdude| |
+|1.5.8    |4.8.1    |same as 1.5.7| |
+|1.6.0    |4.8.1    |same as 1.5.7| |
+|1.6.1    |4.8.1    |toolchains upgrade, added ATmega48/88/168PB, ATA5702M322, ATA5782; added RAMSTART to io*.h| |
+|1.6.2    |packed    | | |
+|1.6.3    |4.8.1    |toolchains upgrade, cleaned| |
+|1.6.4    |4.8.1    |almost the same as 1.6.1| |
+|1.6.5-r5 |4.8.1    |same as 1.6.4| |
+|1.6.6    |4.8.1    |same as 1.6.4| |
+|1.6.7    |4.8.1    |same as 1.6.4| |
+|1.6.8    |4.8.1    |same as 1.6.4| |
+|1.6.9    |4.8.1    |same as 1.6.4| yes |
+|1.6.10   |4.9.2    |toolchains upgrade, , avrdude 6.3 | |
+|1.6.11   |4.9.2    |same as 1.6.10, back to avrdude 6.0.1| |
+|1.6.12   |4.9.2    |same as 1.6.10, patched avrdude 6.3| |
+|1.6.13   |4.9.2    |same as 1.6.12| yes |
+|1.8.0    |4.9.2    |same as 1.6.12, another patch for avrdude 6.3 | |
+|1.8.1    |4.9.2    |same as 1.8.0| |
+|1.8.2    |4.9.2    |recompiled, new toolchains, lot of changes| |
+|1.8.3    |4.9.2    |same as 1.8.2| yes |

--- a/docs/arduino-gcc-versions.md
+++ b/docs/arduino-gcc-versions.md
@@ -37,4 +37,5 @@ based on Linux versions.
 |1.8.0    |4.9.2    |same as 1.6.12, another patch for avrdude 6.3 | |
 |1.8.1    |4.9.2    |same as 1.8.0| |
 |1.8.2    |4.9.2    |recompiled, new toolchains, lot of changes| |
-|1.8.3    |4.9.2    |same as 1.8.2| yes |
+|1.8.3    |4.9.2    |same as 1.8.2| |
+|1.8.4    |4.9.2    |same as 1.8.2| yes |

--- a/docs/arduino-gcc-versions.md
+++ b/docs/arduino-gcc-versions.md
@@ -38,4 +38,5 @@ based on Linux versions.
 |1.8.1    |4.9.2    |same as 1.8.0| |
 |1.8.2    |4.9.2    |recompiled, new toolchains, lot of changes| |
 |1.8.3    |4.9.2    |same as 1.8.2| |
-|1.8.4    |4.9.2    |same as 1.8.2| yes |
+|1.8.4    |4.9.2    |same as 1.8.2| |
+|1.8.5    |4.9.2    |same as 1.8.2| yes |

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -30,11 +30,11 @@ function download_and_unpack()
 
     # check if tools are already in place
     if [ -d arduino-$1/hardware/tools/avr ]; then
-	echo "Package $ver already downloaded and extracted, skipping"
+	echo "Arduino version $1 already downloaded and extracted, skipping"
 	return
     fi
 
-    echo "Downloading version $1"
+    echo "Downloading Arduino version $1"
     
     # default package extension
     local arduExt="tar.xz"

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -2,7 +2,7 @@
 
 LOCAL_TOOLS_DIR=$HOME/avr-tools
 MAKE_PACKAGE=make_4.1-6_amd64.deb
-WGET_FLAGS="--retry-connrefused --tries=3 --timeout=60"
+WGET_FLAGS="--retry-connrefused --tries=3 --timeout=60 --continue"
 
 
 if [ -z "$TRAVIS_BUILD_DIR" ]; then
@@ -47,6 +47,7 @@ function download_and_unpack()
     wget $WGET_FLAGS "http://downloads.arduino.cc/arduino-$1-linux64.$arduExt"
     if [ $? -ne 0 ]; then
 	echo "ERROR: Can't download Arduino"
+	rm arduino-$1-linux64.$arduExt*
 	exit 1
     fi
     
@@ -56,16 +57,17 @@ function download_and_unpack()
 	cat arduino-$1.md5sum.txt|grep "linux64"|md5sum -c
 	if [ $? -ne 0 ]; then
 	    echo "ERROR: md5sum for downloaded Arduino doesn't match"
+	    rm arduino-$1.md5sum.txt*
 	    exit 1
 	fi
-	rm arduino-$1.md5sum.txt
+	rm arduino-$1.md5sum.txt*
     fi
     
     # extract only avr-gcc
     tar xf arduino-$1-linux64.$arduExt --wildcards '*/hardware/tools/avr/'
 
     # clean up
-    rm arduino-$1-linux64.$arduExt    
+    rm arduino-$1-linux64.$arduExt*
 }
 
 function get_make4()

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -53,7 +53,7 @@ function download_and_unpack()
     # try to check md5sum, but Arduino provide only checksums for version 1.6 and greater
     wget $WGET_FLAGS https://downloads.arduino.cc/arduino-$1.md5sum.txt
     if [ $? -eq -0 ]; then
-	md5sum --ignore-missing -c arduino-$1.md5sum.txt
+	cat arduino-$1.md5sum.txt|grep "linux64"|md5sum -c
 	if [ $? -ne 0 ]; then
 	    echo "ERROR: md5sum for downloaded Arduino doesn't match"
 	    exit 1

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+LOCAL_TOOLS_DIR=$HOME/avr-tools
+MAKE_PACKAGE=make_4.1-6_amd64.deb
+WGET_FLAGS="--retry-connrefused --tries=3 --timeout=60"
+
+
+if [ -z "$TRAVIS_BUILD_DIR" ]; then
+    echo "This script should be run by Travis-CI environment"
+    echo "If you want to simulate Travis build, please set TRAVIS_BUILD_DIR"
+    echo "envirinment variable to directory where your code lives"
+    exit 1
+fi
+
+if [ -z "$1" ]; then
+    echo "Arduino version required"
+    exit 1
+fi
+
+if [ -z "$2" ]; then
+    echo "Target required"
+    exit 1
+fi
+
+
+# oownload and unpack package
+function download_and_unpack()
+{
+    cd $LOCAL_TOOLS_DIR
+
+    # check if tools are already in place
+    if [ -d arduino-$1/hardware/tools/avr ]; then
+	echo "Package $ver already downloaded and extracted, skipping"
+	return
+    fi
+
+    echo "Downloading version $1"
+    
+    # default package extension
+    local arduExt="tar.xz"
+    
+    # for packages in version <1.6 extension is .tgz
+    local regex="1\.[05]"
+    if [[ "$1" =~ $regex ]]; then arduExt="tgz"; fi
+    
+    # download package
+    wget $WGET_FLAGS "http://downloads.arduino.cc/arduino-$1-linux64.$arduExt"
+    if [ $? -ne 0 ]; then
+	echo "ERROR: Can't download Arduino"
+	exit 1
+    fi
+    
+    # try to check md5sum, but Arduino provide only checksums for version 1.6 and greater
+    wget $WGET_FLAGS https://downloads.arduino.cc/arduino-$1.md5sum.txt
+    if [ $? -eq -0 ]; then
+	md5sum --ignore-missing -c arduino-$1.md5sum.txt
+	if [ $? -ne 0 ]; then
+	    echo "ERROR: md5sum for downloaded Arduino doesn't match"
+	    exit 1
+	fi
+	rm arduino-$1.md5sum.txt
+    fi
+    
+    # extract only avr-gcc
+    tar xf arduino-$1-linux64.$arduExt --wildcards '*/hardware/tools/avr/'
+
+    # clean up
+    rm arduino-$1-linux64.$arduExt    
+}
+
+function get_make4()
+{
+    cd $LOCAL_TOOLS_DIR
+    
+    # check for existence
+    if [ -x usr/bin/make ]; then
+	echo "Make already in place, skipping"
+	return
+    fi
+    
+    # download
+    wget http://archive.ubuntu.com/ubuntu/pool/main/m/make-dfsg/$MAKE_PACKAGE
+    if [ $? -ne 0 ]; then
+	echo "ERROR: Can't download make4"
+	exit 1
+    fi
+    
+    # unpack
+    dpkg-deb -x $MAKE_PACKAGE $LOCAL_TOOLS_DIR
+
+    # clean up
+    rm ${MAKE_PACKAGE}*
+}
+
+# make directory for tools
+mkdir -p $LOCAL_TOOLS_DIR
+
+# get new make as Optiboot requires version >4.0
+get_make4
+
+# download specific Arduino version
+download_and_unpack $1
+
+# set search path
+PATH=$LOCAL_TOOLS_DIR/usr/bin:$PATH:$LOCAL_TOOLS_DIR/arduino-$1/hardware/tools/avr/bin
+
+cd $TRAVIS_BUILD_DIR/optiboot/bootloaders/optiboot
+
+make --version
+make clean
+make $2


### PR DESCRIPTION
This is very basic support, it compiles Optiboot using
avr-tools only from one Arduino version, currently 1.6.9.
Attiny84 is in 'allow_failures' as it currently doesn't
compile on any version of tools.