### PR TITLE
unable to build for atmega1284 and to program lock byte

### DIFF
--- a/optiboot/bootloaders/optiboot/Makefile.1284
+++ b/optiboot/bootloaders/optiboot/Makefile.1284
@@ -139,3 +139,23 @@ wildfirev3_isp: LFUSE ?= F7
 # 2.7V brownout
 wildfirev3_isp: EFUSE ?= FD
 wildfirev3_isp: isp
+
+xplbee: TARGET = $@
+xplbee: CHIP = atmega1284p
+xplbee:
+	$(MAKE) $(CHIP) AVR_FREQ=16000000L LED=B7
+	mv $(PROGRAM)_$(CHIP).hex $(PROGRAM)_$(TARGET).hex
+	mv $(PROGRAM)_$(CHIP).lst $(PROGRAM)_$(TARGET).lst
+
+xplbee_isp: xplbee
+xplbee_isp: TARGET = xplbee
+xplbee_isp: MCU_TARGET = atmega1284p
+xplbee_isp: ISPTOOL ?= dragon_jtag
+xplbee_isp: ISPPORT ?= usb
+# 1024 byte boot, JTAG Enabled
+xplbee_isp: HFUSE ?= 9E
+# Full Swing xtal (16MHz) 16KCK/14CK+65ms
+xplbee_isp: LFUSE ?= F7
+# 2.7V brownout
+xplbee_isp: EFUSE ?= FD
+xplbee_isp: isp

--- a/optiboot/bootloaders/optiboot/Makefile.1284
+++ b/optiboot/bootloaders/optiboot/Makefile.1284
@@ -15,6 +15,7 @@ atmega644p: LDSECTIONS  = -Wl,--section-start=.text=0xfc00 -Wl,--section-start=.
 atmega644p: CFLAGS += $(UART_CMD)
 atmega644p: $(PROGRAM)_atmega644p.hex
 atmega644p: $(PROGRAM)_atmega644p.lst
+atmega644p: LIBS=-latmega644
 
 atmega1284: TARGET = atmega1284p
 atmega1284: MCU_TARGET = atmega1284p
@@ -24,6 +25,7 @@ atmega1284: LDSECTIONS  = -Wl,--section-start=.text=0x1fc00 -Wl,--section-start=
 atmega1284: CFLAGS += $(UART_CMD)
 atmega1284: $(PROGRAM)_atmega1284p.hex
 atmega1284: $(PROGRAM)_atmega1284p.lst
+atmega1284: LIBS=-latmega1284
 
 atmega1284p: atmega1284
 

--- a/optiboot/bootloaders/optiboot/Makefile.isp
+++ b/optiboot/bootloaders/optiboot/Makefile.isp
@@ -57,7 +57,7 @@ endif
 #
 # avrdude commands to erase chip, unlock memory, and program fuses.
 #
-ISPFUSES =	-e -u -U lock:w:0x3f:m $(EFUSE_CMD) \
+ISPFUSES =	-e -u -U lock:w:0xff:m $(EFUSE_CMD) \
 	 	-U hfuse:w:0x$(HFUSE):m -U lfuse:w:0x$(LFUSE):m
 
 
@@ -66,7 +66,7 @@ ISPFUSES =	-e -u -U lock:w:0x3f:m $(EFUSE_CMD) \
 # space from accidental SPM writes.  Note: "2f" allows boot section to be read
 # by the application, which is different than the arduino default.
 #
-ISPFLASH =	-U flash:w:$(PROGRAM)_$(TARGET).hex -U lock:w:0x2f:m
+ISPFLASH =	-U flash:w:$(PROGRAM)_$(TARGET).hex -U lock:w:0xef:m
 
 # There are certain complicated caused by the fact that the default state
 # of a fuse is a "1" rather than a "0", especially with respect to fuse bits


### PR DESCRIPTION
Hi,
I propose the modifications attached, in order to allow the compilation in BIGBOOT under Linux for me: 

> Ubuntu 16.04, x86_64, avr-gcc (AVR_8_bit_GNU_Toolchain_3.5.4_1709)

These changes resolve the following errors:

* the read and write functions in the EEPROM are not added during link editing:

        optiboot.o:` In function `main ':
        optiboot.c :(. init9 + 0x130): undefined reference to `eeprom_write_byte '
        optiboot.c :( init9 + 0x1a6): undefined reference to `eeprom_read_byte '
        collect2: error: ld returned 1 exit status

* Checking the lock byte fails:

        avrdude: verification error, first mismatch at byte 0x0000
                  0xff! = 0x3f
        avrdude: verification error; content mismatch

        avrdude: verification error, first mismatch at byte 0x0000
                  0xef! = 0x2f
        avrdude: verification error; content mismatch

Thank you for your superb work.