### PR TITLE
Makefile: help target: added -e option to echo command for escaped output to show correct

### DIFF
--- a/optiboot/bootloaders/optiboot/Makefile
+++ b/optiboot/bootloaders/optiboot/Makefile
@@ -613,4 +613,4 @@ clean:
 	$(OBJCOPY) -j .text -j .data -j .version --set-section-flags .version=alloc,load -O binary $< $@
 
 help:
-	@echo $(HELPTEXT)
+	@echo -e $(HELPTEXT)


### PR DESCRIPTION
Command: "make help" did now display correctly - (escaped) newlines was litterly shown as \n in output
