### PR TITLE
Travis-CI: targets update, compilation matrix with sizes, documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,17 @@ cache:
     - $HOME/avr-tools    
 install: true
 
+stages:
+  - check sizes
+  - test
+
 env:
   global:
-#    - ARDUINO_VERSION=1.0.6
-    - ARDUINO_VERSION=1.6.9
-#    - ARDUINO_VERSION=1.6.13
-#    - ARDUINO_VERSION=1.8.5
+#    - TOOLS_VERSION=1.0.6
+#    - TOOLS_VERSION=1.6.9
+#    - TOOLS_VERSION=1.6.13
+#    - TOOLS_VERSION=1.8.5
+    - TOOLS_VERSION=microchip    
   matrix:
     - OPTIBOOT_TARGET=bobuino
     - OPTIBOOT_TARGET=diecimila
@@ -41,17 +46,66 @@ env:
     - OPTIBOOT_TARGET=atmega168p
     - OPTIBOOT_TARGET=atmega32
     - OPTIBOOT_TARGET=atmega328
+    - OPTIBOOT_TARGET="atmega328 LED_START_FLASHES=0"
+    - OPTIBOOT_TARGET="atmega328 LED_START_FLASHES=0 SUPPORT_EEPROM=1"
+    - OPTIBOOT_TARGET="atmega328 LED_START_FLASHES=0 LED_START_ON=1 SUPPORT_EEPROM=1"
+    - OPTIBOOT_TARGET="atmega328 SOFT_UART=1"
+    - OPTIBOOT_TARGET="atmega328 BIGBOOT=1"
     - OPTIBOOT_TARGET=atmega328_pro8
     - OPTIBOOT_TARGET=atmega644p
     - OPTIBOOT_TARGET=atmega8
     - OPTIBOOT_TARGET=atmega88
     - OPTIBOOT_TARGET=attiny84
+    - OPTIBOOT_TARGET=attiny1634
+    - OPTIBOOT_TARGET=attiny841
+    - OPTIBOOT_TARGET=attiny828
+    - OPTIBOOT_TARGET=atmega2560
+    - OPTIBOOT_TARGET=mega2560
+    - OPTIBOOT_TARGET="atmega64"
+    - OPTIBOOT_TARGET="atmega88p LED=B5"
+    - OPTIBOOT_TARGET="atmega88pb LED=B5"
+    - OPTIBOOT_TARGET=atmega128
+    - OPTIBOOT_TARGET=atmega162
+    - OPTIBOOT_TARGET=atmega164a
+    - OPTIBOOT_TARGET=atmega164p
+    - OPTIBOOT_TARGET="atmega168pb LED=B5"
+    - OPTIBOOT_TARGET=atmega169
+    - OPTIBOOT_TARGET=atmega169p
+    - OPTIBOOT_TARGET=atmega324a
+    - OPTIBOOT_TARGET=atmega324p
+    - OPTIBOOT_TARGET=atmega324pa
+    - OPTIBOOT_TARGET=atmega324pb
+    - OPTIBOOT_TARGET="atmega328pb LED=B5"
+    - OPTIBOOT_TARGET=atmega329
+    - OPTIBOOT_TARGET=atmega329p
+    - OPTIBOOT_TARGET=atmega640
+    - OPTIBOOT_TARGET=atmega644p
+    - OPTIBOOT_TARGET=atmega649
+    - OPTIBOOT_TARGET=atmega649p
+    - OPTIBOOT_TARGET=atmega1281
+    - OPTIBOOT_TARGET=atmega2561
+    - OPTIBOOT_TARGET=atmega3290
+    - OPTIBOOT_TARGET=atmega3290p
+    - OPTIBOOT_TARGET=atmega6490
+    - OPTIBOOT_TARGET=atmega6490p
+    - OPTIBOOT_TARGET=atmega8515
+    - OPTIBOOT_TARGET=atmega8535
+    - OPTIBOOT_TARGET=attiny167
+    - OPTIBOOT_TARGET=attiny87
 
 matrix:
   allow_failures:
-    - env: OPTIBOOT_TARGET=attiny84
+    - env: OPTIBOOT_TARGET=attiny828
+    - env: OPTIBOOT_TARGET=atmega324pb
+    - env: OPTIBOOT_TARGET="atmega328pb LED=B5"
 
-script: scripts/travis-build.sh $ARDUINO_VERSION $OPTIBOOT_TARGET
+script: scripts/travis-build.sh $TOOLS_VERSION $OPTIBOOT_TARGET
+
+jobs:
+  include:
+    - stage: check sizes
+      script: scripts/travis-check-sizes.sh
+      env: OPTIBOOT_TARGET=none
 
 notifications:
   email:

--- a/docs/travis-ci.md
+++ b/docs/travis-ci.md
@@ -1,0 +1,74 @@
+# Travis-CI and Optiboot
+
+## What is Travis?
+
+https://travis-ci.com is site which allows to make checking builds after
+every push of code to git repository. It could also check pull request.
+
+It nicely integrates with Github, so to enable it's enough to just
+install Travis' Github App from: https://github.com/marketplace/travis-ci
+
+Travis have also free plan for Open Source projects, so there is no
+cost involved.
+
+When installed, after every push a build is started on Travis-CI
+servers. After build finish, status of commit is updated, so everyone
+can see if build passed or failed. Clicking on details gives more
+information about which job(s) within all build failed and even direct
+output from virtual machine, so it's easy to check why something went
+wrong.
+
+Of course, Travis-CI also needs configuration to define what should
+be run to test code, so every project must have *.travis.yml* file
+and some others if external scripts are needed.
+
+## Files
+
+### .travis.yml
+
+Standard Travis-CI file with definitions of jobs.
+
+There are 2 stages of tests:
+- *check sizes*: there is only one build in this stage which compiles ALL
+targets specified in *.travis.yml* (variable *OPTIBOOT_TARGET* in matrix)
+agains ALL compilers marked with 'yes' from *arduino-gcc-versions.md* file
+plus latest Microchip's compiler for avr8. There are 2 tables produced
+at the end of build: one is output of current compilation and resulting
+sizes for every target or 'x' if build failed. Second one is based on
+online database of builds and gives comparison between current build
+and last commited into repository. Output is markdown compatible, so
+it could be just copied and pasted into Github comment to produce
+pretty table.
+- test: stage with separate build for every *OPTIBOOT_TARGET* against only
+one compiler specified in variable *TOOLS_VERSION*. In 'allow_failures'
+section there are targets known to fail and ignored in overall status
+of test.
+
+### scripts/travis-build.sh
+
+Script used to build single target during 'test' stage.
+
+## scripts/travis-check-sizes.sh
+
+Script used to build all targets using all compilers during 'check sizes'
+stage.
+
+## scripts/travis-download.inc.sh
+
+Include script used to download and unpack tools. Used by *travis-build.sh*
+and *travis-check-sizes.sh* scripts.
+
+## scripts/travis-env.inc.sh
+
+Helper script for local testing (on Linux) builds. It sets all necessary
+environment variables to make *travis-build.sh* or *travis-check-sizes.sh*
+on local machine. Need to be sourced from repository parent directory:
+```bash
+. scripts/travis-env.inc.sh
+```
+
+## scripts/travis-fill-cache.sh
+
+Helper script used by *travis-check-sizes.sh* to download and extract all
+needed compilers. It uses *docs/arduino-gcc-versions.md* file to find
+which Arduino version should be downloaded.

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
 
 LOCAL_TOOLS_DIR=$HOME/avr-tools
-MAKE_PACKAGE=make_4.1-6_amd64.deb
-WGET_FLAGS="--retry-connrefused --tries=3 --timeout=60 --continue"
-
 
 if [ -z "$TRAVIS_BUILD_DIR" ]; then
     echo "This script should be run by Travis-CI environment"
     echo "If you want to simulate Travis build, please set TRAVIS_BUILD_DIR"
-    echo "envirinment variable to directory where your code lives"
+    echo "environment variable to directory where your code lives"
     exit 1
 fi
 
@@ -23,91 +20,32 @@ if [ -z "$2" ]; then
 fi
 
 
-# oownload and unpack package
-function download_and_unpack()
-{
-    cd $LOCAL_TOOLS_DIR
+# Include functions to download stuff
+. $TRAVIS_BUILD_DIR/scripts/travis-download.inc.sh
 
-    # check if tools are already in place
-    if [ -d arduino-$1/hardware/tools/avr ]; then
-	echo "Arduino version $1 already downloaded and extracted, skipping"
-	return
-    fi
-
-    echo "Downloading Arduino version $1"
-    
-    # default package extension
-    local arduExt="tar.xz"
-    
-    # for packages in version <1.6 extension is .tgz
-    local regex="1\.[05]"
-    if [[ "$1" =~ $regex ]]; then arduExt="tgz"; fi
-    
-    # download package
-    wget $WGET_FLAGS "http://downloads.arduino.cc/arduino-$1-linux64.$arduExt"
-    if [ $? -ne 0 ]; then
-	echo "ERROR: Can't download Arduino"
-	rm arduino-$1-linux64.$arduExt*
-	exit 1
-    fi
-    
-    # try to check md5sum, but Arduino provide only checksums for version 1.6 and greater
-    wget $WGET_FLAGS https://downloads.arduino.cc/arduino-$1.md5sum.txt
-    if [ $? -eq -0 ]; then
-	cat arduino-$1.md5sum.txt|grep "linux64"|md5sum -c
-	if [ $? -ne 0 ]; then
-	    echo "ERROR: md5sum for downloaded Arduino doesn't match"
-	    rm arduino-$1.md5sum.txt*
-	    exit 1
-	fi
-	rm arduino-$1.md5sum.txt*
-    fi
-    
-    # extract only avr-gcc
-    tar xf arduino-$1-linux64.$arduExt --wildcards '*/hardware/tools/avr/'
-
-    # clean up
-    rm arduino-$1-linux64.$arduExt*
-}
-
-function get_make4()
-{
-    cd $LOCAL_TOOLS_DIR
-    
-    # check for existence
-    if [ -x usr/bin/make ]; then
-	echo "Make already in place, skipping"
-	return
-    fi
-    
-    # download
-    wget http://archive.ubuntu.com/ubuntu/pool/main/m/make-dfsg/$MAKE_PACKAGE
-    if [ $? -ne 0 ]; then
-	echo "ERROR: Can't download make4"
-	exit 1
-    fi
-    
-    # unpack
-    dpkg-deb -x $MAKE_PACKAGE $LOCAL_TOOLS_DIR
-
-    # clean up
-    rm ${MAKE_PACKAGE}*
-}
-
-# make directory for tools
+# Make directory for tools
 mkdir -p $LOCAL_TOOLS_DIR
 
 # get new make as Optiboot requires version >4.0
-get_make4
+download_make4
 
-# download specific Arduino version
-download_and_unpack $1
+# download specific tools version
+if [ "$1" = "microchip" ]; then
+    download_avr_toolchain
 
-# set search path
-PATH=$LOCAL_TOOLS_DIR/usr/bin:$PATH:$LOCAL_TOOLS_DIR/arduino-$1/hardware/tools/avr/bin
+    # set search path
+    PATH=$LOCAL_TOOLS_DIR/usr/bin:$PATH:$LOCAL_TOOLS_DIR/avr8-gnu-toolchain-linux_x86_64/bin
+    avr-gcc --version
+else
+    download_arduino $1
+
+    # set search path
+    PATH=$LOCAL_TOOLS_DIR/usr/bin:$PATH:$LOCAL_TOOLS_DIR/arduino-$1/hardware/tools/avr/bin
+fi
 
 cd $TRAVIS_BUILD_DIR/optiboot/bootloaders/optiboot
 
 make --version
 make clean
-make $2
+shift
+make $@

--- a/scripts/travis-check-sizes.sh
+++ b/scripts/travis-check-sizes.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+LOCAL_TOOLS_DIR=$HOME/avr-tools
+
+if [ -z "$TRAVIS_BUILD_DIR" ]; then
+    echo "This script should be run by Travis-CI environment"
+    echo "If you want to simulate Travis build, please set TRAVIS_BUILD_DIR"
+    echo "environment variable to directory where your code lives"
+    exit 1
+fi
+
+
+# download all compilers
+$TRAVIS_BUILD_DIR/scripts/travis-fill-cache.sh
+
+# prepare output dir
+OUTPUT_DIR="$TRAVIS_BUILD_DIR/sizes-out"
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_TABLE="$OUTPUT_DIR/sizes.txt"
+OUTPUT_JSON="$OUTPUT_DIR/sizes.json"
+
+# compiler list
+COMPILERS=$(cat $TRAVIS_BUILD_DIR/docs/arduino-gcc-versions.md |grep -i "| yes |"|cut -f 2 -d '|')
+COMPILERS="$COMPILERS microchip"
+
+# table header
+echo -n "| target \ compiler |" >"$OUTPUT_TABLE"
+for compiler in $COMPILERS; do
+  echo -n " $compiler |" >>"$OUTPUT_TABLE"
+done
+echo >>"$OUTPUT_TABLE"
+# table header separator
+echo -n "|-|" >>"$OUTPUT_TABLE"
+for compiler in $COMPILERS; do
+    echo -n "-|">>"$OUTPUT_TABLE"
+done
+echo >>"$OUTPUT_TABLE"
+
+# get repo and commit info for json output
+if [[ "$TRAVIS_PULL_REQUEST" = "false" ]]; then
+    REPO="$TRAVIS_REPO_SLUG"
+    BRANCH="$TRAVIS_BRANCH"
+else
+    REPO="$TRAVIS_PULL_REQUEST_SLUG"
+    BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
+fi
+
+# start json
+echo "{\"slug\":\"$REPO\",\"branch\":\"$BRANCH\",\"commit\":\"$TRAVIS_COMMIT\",\"emoji\":\"false\",\"builds\":[" >"$OUTPUT_JSON"
+
+# build everything
+cat $TRAVIS_BUILD_DIR/.travis.yml|grep "    - OPTIBOOT_TARGET="|cut -f 2- -d '=' \
+  |tr -d '"'|sort|while read target; do
+    echo -n "| $target |" >>"$OUTPUT_TABLE"
+    echo "{\"t\":\"$target\",\"v\":[">>"$OUTPUT_JSON"
+    for compiler in $COMPILERS; do
+	echo "Checking size for $target @ $compiler"
+	size=$($TRAVIS_BUILD_DIR/scripts/travis-build.sh $compiler $target 2>/dev/null|grep -A 2 avr-size|tail -n1|awk '{ print $1;}')
+	if [[ -z "$size" ]]; then
+	    size="x"
+	fi
+	echo -n " $size |" >>"$OUTPUT_TABLE"
+	echo "{\"c\":\"$compiler\",\"s\":\"$size\"}," >>"$OUTPUT_JSON"
+    done
+    echo >>"$OUTPUT_TABLE"
+    sed -i '$ s/.$//' "$OUTPUT_JSON"
+    echo "]}," >>"$OUTPUT_JSON"
+done
+sed -i '$ s/.$//' "$OUTPUT_JSON"
+echo "]}">>"$OUTPUT_JSON"
+
+echo "========= OUTPUT SIZES START ============="
+cat "$OUTPUT_TABLE"
+echo "========== OUTPUT SIZES END =============="
+
+echo "Checking results against last commit"
+echo "========= OUTPUT SIZES COMPARE START ============="
+curl -H "Content-Type: application/json" --data @$OUTPUT_JSON https://api.travisjoin.w7i.pl/tj/compare/$REPO/$BRANCH/last
+echo "========== OUTPUT SIZES COMPARE END =============="
+
+echo "Uploading results to TravisJoin"
+curl -H "Content-Type: application/json" --data @$OUTPUT_JSON https://api.travisjoin.w7i.pl/tj/add/$REPO/$BRANCH/$TRAVIS_COMMIT
+
+exit 0

--- a/scripts/travis-download.inc.sh
+++ b/scripts/travis-download.inc.sh
@@ -1,0 +1,104 @@
+# common functions to get avr-gcc tools
+#
+
+MAKE_PACKAGE=make_4.1-6_amd64.deb
+WGET_FLAGS="--retry-connrefused --tries=3 --timeout=60 --continue"
+
+
+# download and unpack package
+function download_arduino()
+{
+    cd $LOCAL_TOOLS_DIR
+
+    # check if tools are already in place
+    if [ -d arduino-$1/hardware/tools/avr ]; then
+	echo "Arduino version $1 already downloaded and extracted, skipping"
+	return
+    fi
+
+    echo "Downloading Arduino version $1"
+    
+    # default package extension
+    local arduExt="tar.xz"
+    
+    # for packages in version <1.6 extension is .tgz
+    local regex="1\.[05]"
+    if [[ "$1" =~ $regex ]]; then arduExt="tgz"; fi
+    
+    # download package
+    wget $WGET_FLAGS "http://downloads.arduino.cc/arduino-$1-linux64.$arduExt"
+    if [ $? -ne 0 ]; then
+	echo "ERROR: Can't download Arduino"
+	rm arduino-$1-linux64.$arduExt*
+	exit 1
+    fi
+    
+    # try to check md5sum, but Arduino provide only checksums for version 1.6 and greater
+    wget $WGET_FLAGS https://downloads.arduino.cc/arduino-$1.md5sum.txt
+    if [ $? -eq -0 ]; then
+	cat arduino-$1.md5sum.txt|grep "linux64"|md5sum -c
+	if [ $? -ne 0 ]; then
+	    echo "ERROR: md5sum for downloaded Arduino doesn't match"
+	    rm arduino-$1.md5sum.txt*
+	    exit 1
+	fi
+	rm arduino-$1.md5sum.txt*
+    fi
+    
+    # extract only avr-gcc
+    tar xf arduino-$1-linux64.$arduExt --wildcards '*/hardware/tools/avr/'
+
+    # clean up
+    rm arduino-$1-linux64.$arduExt*
+}
+
+function download_make4()
+{
+    cd $LOCAL_TOOLS_DIR
+    
+    # check for existence
+    if [ -x usr/bin/make ]; then
+	echo "Make already in place, skipping"
+	return
+    fi
+    
+    # download
+    wget http://archive.ubuntu.com/ubuntu/pool/main/m/make-dfsg/$MAKE_PACKAGE
+    if [ $? -ne 0 ]; then
+	echo "ERROR: Can't download make4"
+	exit 1
+    fi
+    
+    # unpack
+    dpkg-deb -x $MAKE_PACKAGE $LOCAL_TOOLS_DIR
+
+    # clean up
+    rm ${MAKE_PACKAGE}*
+}
+
+function download_avr_toolchain()
+{
+    cd $LOCAL_TOOLS_DIR
+
+    # check if tools are already in place
+    if [ -d avr8-gnu-toolchain-linux_x86_64 ]; then
+	echo "AVR 8-bit Toolchain already downloaded and extracted, skipping"
+	return
+    fi
+
+    echo "Downloading AVR 8-bit Toolchain"
+    
+    # download package
+    wget $WGET_FLAGS --content-disposition "https://www.microchip.com/mymicrochip/filehandler.aspx?ddocname=en605750"
+    if [ $? -ne 0 ]; then
+	echo "ERROR: Can't download AVR 8-bit Toolchain"
+	rm avr8-gnu-toolchain-*-linux.any.x86_64.tar.gz*
+	exit 1
+    fi
+    
+    # unpack
+    tar xf avr8-gnu-toolchain-*-linux.any.x86_64.tar.gz
+    
+    # clean up
+    rm avr8-gnu-toolchain-*-linux.any.x86_64.tar.gz*
+}

--- a/scripts/travis-env.inc.sh
+++ b/scripts/travis-env.inc.sh
@@ -1,0 +1,26 @@
+# source it from parent directory to mimic Travis-CI
+# environmental variables needed in scripts
+
+if [[ -d .git ]]; then
+    export TRAVIS_BUILD_DIR=`pwd`
+else
+    echo "ERROR: include it from repository parent directory!!!"
+    return
+fi
+
+export TRAVIS_COMMIT="THIS_IS_FAKE_COMMIT_HASH_FOR_TESTS_ONLY1"
+export TRAVIS_COMMIT_MESSAGE="Example commit message"
+export TRAVIS_EVENT_TYPE="push"
+export TRAVIS_OS_NAME="linux"
+export TRAVIS_PULL_REQUEST="false"
+export TRAVIS_PULL_REQUEST_BRANCH=""
+export TRAVIS_PULL_REQUEST_SHA=""
+export TRAVIS_PULL_REQUEST_SLUG=""
+
+export TRAVIS_REPO_SLUG=$(git config --get travis.slug)
+if [[ -z "$TRAVIS_REPO_SLUG" ]]; then
+    export TRAVIS_REPO_SLUG=$(git config --get remote.origin.url|sed 's/.*github\.com.//'|sed 's/\.git$//')
+fi
+
+export TRAVIS_SUDO="false"
+export TRAVIS_BRANCH=$(git rev-parse --abbrev-ref HEAD)

--- a/scripts/travis-fill-cache.sh
+++ b/scripts/travis-fill-cache.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Download avr-gcc from Arduino and Microchip
+# Get also make 4 required to compile Optiboot
+#
+
+# path where tools are extracted
+LOCAL_TOOLS_DIR=$HOME/avr-tools
+
+
+# check if we are running by Travis-CI
+if [ -z "$TRAVIS_BUILD_DIR" ]; then
+    echo "This script should be run by Travis-CI environment"
+    echo "If you want to simulate Travis build, please set TRAVIS_BUILD_DIR"
+    echo "environment variable to directory where your code lives"
+    exit 1
+fi
+
+# include functions to download stuff
+. $TRAVIS_BUILD_DIR/scripts/travis-download.inc.sh
+
+# make directory for tools
+mkdir -p $LOCAL_TOOLS_DIR
+
+# get new make as Optiboot requires version >4.0
+download_make4
+
+# download Arduino versions
+for version in $(cat $TRAVIS_BUILD_DIR/docs/arduino-gcc-versions.md |grep -i "| yes |"|cut -f 2 -d '|'); do
+    download_arduino $version
+done
+
+# download Microchip's AVR8 Toolchain
+download_avr_toolchain


### PR DESCRIPTION
- added new targets from MCUdude
- added new ATTiny and ATmega cpus
- updated ignore list
- added some documentation
- build uses stages: in first stage a matrix of all targets and compilers is checked and produce table with build status and resulting sizes. Additionally it checks online commit database to compare sizes to last commit, output is also table.
- new scripts, old are rewritten
- switch to default build using Microchip's toolchains