### PR TITLE
Fix baud rate setting for single speed mode

### DIFF
--- a/optiboot/bootloaders/optiboot/optiboot.c
+++ b/optiboot/bootloaders/optiboot/optiboot.c
@@ -609,13 +609,13 @@ int main(void) {
   #endif //singlespeed
   UCSRB = _BV(RXEN) | _BV(TXEN);  // enable Rx & Tx
   UCSRC = _BV(URSEL) | _BV(UCSZ1) | _BV(UCSZ0);  // config USART; 8N1
-  UBRRL = (uint8_t)( (F_CPU + BAUD_RATE * 4L) / (BAUD_RATE * 8L) - 1 );
+  UBRRL = (uint8_t)BAUD_SETTING;
   #else // mega8/etc
     #ifdef LIN_UART
   //DDRB|=3;
   LINCR = (1 << LSWRES); 
   //LINBRRL = (((F_CPU * 10L / 32L / BAUD_RATE) + 5L) / 10L) - 1; 
-  LINBRRL=(uint8_t)( (F_CPU + BAUD_RATE * 4L) / (BAUD_RATE * 8L) - 1 );
+  LINBRRL=(uint8_t)BAUD_SETTING;
   LINBTR = (1 << LDISR) | (8 << LBT0); 
   LINCR = _BV(LENA) | _BV(LCMD2) | _BV(LCMD1) | _BV(LCMD0); 
   LINDAT=0;
@@ -625,7 +625,7 @@ int main(void) {
       #endif
   UART_SRB = _BV(RXEN0) | _BV(TXEN0);
   UART_SRC = _BV(UCSZ00) | _BV(UCSZ01);
-  UART_SRL = (uint8_t)( (F_CPU + BAUD_RATE * 4L) / (BAUD_RATE * 8L) - 1 );
+  UART_SRL = (uint8_t)BAUD_SETTING;
     #endif // LIN_UART
   #endif // mega8/etc
 #endif // soft_uart


### PR DESCRIPTION
Hardware:
* mcu: atmega8
* baud rate: 38400
* PC side client: avrdude 6.3 (debian stable)

How to reproduce the issue:
* Download current master branch.
* Edit the firmware to `putch` some greetings chars on boot (this is needed to ensure optiboot sends some data to the PC).
* Compile: `make atmega8 AVR_FREQ=16000000 BAUD_RATE=38400 LED=C2 LED_DATA_FLASH=1  LED_START_ON=1 LED_START_FLASHES=3  SINGLESPEED=1`
* Flash the firmware
* Fire up the atmega
* Wrong baud rate pulses can be seen on a scope, and at the same time minicom outputs some corrupted chars.

The issue is caused by a hardcoded formula that doesn't handle the single speed mode.
The proposed solution re-uses the already calculated BAUD_SETTING in order to avoid code duplication (BAUD_SETTING *do* handles single speed mode correctly). Please tell me whether this is acceptable or not.

Thank you.