### PR TITLE
Put BIGBOOT strings in flash so __do_copy_data doesn't get placed ahead of the jump table.

### DIFF
--- a/optiboot/bootloaders/optiboot/optiboot.c
+++ b/optiboot/bootloaders/optiboot/optiboot.c
@@ -1314,7 +1314,8 @@ static void do_spm(uint16_t address, uint8_t command, uint16_t data) {
  */
 #define xstr(s) str(s)
 #define str(s) #s
-#define OPT2FLASH(o) char f##o[] = #o "=" xstr(o)
+#define OPTFLASHSECT __attribute__((section(".fini8")))
+#define OPT2FLASH(o) OPTFLASHSECT const char f##o[] = #o "=" xstr(o)
 
 
 #ifdef LED_START_FLASHES
@@ -1327,7 +1328,7 @@ OPT2FLASH(LED_DATA_FLASH);
 OPT2FLASH(LED_START_ON);
 #endif
 #ifdef LED_NAME
-char f_LED[] = "LED=" LED_NAME;
+OPTFLASHSECT const char f_LED[] = "LED=" LED_NAME;
 #endif
 
 #ifdef SUPPORT_EEPROM
@@ -1343,18 +1344,18 @@ OPT2FLASH(SOFT_UART);
 OPT2FLASH(UART);
 #endif
 
-char f_date[] = "Built:" __DATE__ ":" __TIME__;
+OPTFLASHSECT const char f_date[] = "Built:" __DATE__ ":" __TIME__;
 #ifdef BIGBOOT
 OPT2FLASH(BIGBOOT);
 #endif
 #ifdef VIRTUAL_BOOT_PARTITION
-char f_boot[] = "Virtual_Boot_Partition";
+OPTFLASHSECT const char f_boot[] = "Virtual_Boot_Partition";
 #endif
 OPT2FLASH(F_CPU);
-char f_device[] = "Device=" xstr(__AVR_DEVICE_NAME__);
+OPTFLASHSECT const char f_device[] = "Device=" xstr(__AVR_DEVICE_NAME__);
 #ifdef OPTIBOOT_CUSTOMVER
 OPT2FLASH(OPTIBOOT_CUSTOMVER);
 #endif
-char f_version[] = "Version=" xstr(OPTIBOOT_MAJVER) "." xstr(OPTIBOOT_MINVER);
+OPTFLASHSECT const char f_version[] = "Version=" xstr(OPTIBOOT_MAJVER) "." xstr(OPTIBOOT_MINVER);
 
 #endif


### PR DESCRIPTION
I found when compiling with BIGBOOT that `__do_copy_data` was being placed before the jump table, due to the human-readable config flag info being placed in `.data`. Using the `.progmem` section puts them before most of `.text` still, and using `.text.buildinfo` to sort into the `.text.*` rule produced linker errors (`optiboot.c:(.init9+0x10a): warning: internal error: out of range error
optiboot.c:(.init9+0x168): warning: internal error: out of range error`, on the lines using `eeprom_*_byte()`). I placed them in `.fini8` to get it ordered properly to work, but someone with more linker-fu might have a better solution.