### PR TITLE
added optional copy_flash_pages function to load application from internal flash

### DIFF
--- a/optiboot/bootloaders/optiboot/Makefile
+++ b/optiboot/bootloaders/optiboot/Makefile
@@ -220,7 +220,6 @@ dummy = FORCE
 endif
 endif
 
-
 HELPTEXT += "Option SOFT_UART=1           - use a software (bit-banged) UART\n"
 ifdef SOFT_UART
 ifneq ($(SOFT_UART), 0)
@@ -243,11 +242,19 @@ APPSPM_CMD = -DAPP_NOSPM=1
 endif
 endif
 
+HELPTEXT += "Option COPY_FLASH_PAGES_FNC=1      - add copy_flash_pages function\n"
+ifdef COPY_FLASH_PAGES_FNC
+ifneq ($(COPY_FLASH_PAGES_FNC), 0)
+COPY_FLASH_PAGES_FNC_CMD = -DCOPY_FLASH_PAGES_FNC
+dummy = FORCE
+endif
+endif
+
 
 COMMON_OPTIONS = $(BAUD_RATE_CMD) $(LED_START_FLASHES_CMD) $(BIGBOOT_CMD)
 COMMON_OPTIONS += $(SOFT_UART_CMD) $(LED_DATA_FLASH_CMD) $(LED_CMD) $(SS_CMD)
 COMMON_OPTIONS += $(SUPPORT_EEPROM_CMD) $(LED_START_ON_CMD) $(APPSPM_CMD)
-COMMON_OPTIONS += $(VERSION_CMD)
+COMMON_OPTIONS += $(COPY_FLASH_PAGES_FNC_CMD) $(VERSION_CMD)
 
 #UART is handled separately and only passed for devices with more than one.
 HELPTEXT += "Option UART=n                - use UARTn for communications\n"


### PR DESCRIPTION
the function is added to Optiboot only with build option COPY_FLASH_PAGES_FNC=1

Function copy_flash_pages uses do_spm() function to copy flash pages.
It is intended to be called by the application over the 'vector table' in pre_main().
It uses 32bit addresses for use on devices with more then 64 kB flash memory.
The destination and source address must be page aligned.
Additionally parameter reset_mcu activates an (almost) immediate watchdog reset of the MCU after pages are copied.

It was created to copy a new version of the application stored in the upper half of the flash memory to the beginning of the flash and then reset the MCU to run the new version. 
It is used by ArduinoOTA libray in [InternalStorageAVR](https://github.com/jandrassy/ArduinoOTA/blob/master/src/InternalStorageAVR.cpp) over utility/optiboot.h.

To fit into 1 kB,  COPY_FLASH_PAGES_FNC option excludes the version information section otherwise added to BIGBOOT builds.
