### PR TITLE
change OSCCAL in bootloader

### DIFF
--- a/optiboot/bootloaders/optiboot/Makefile
+++ b/optiboot/bootloaders/optiboot/Makefile
@@ -243,11 +243,17 @@ APPSPM_CMD = -DAPP_NOSPM=1
 endif
 endif
 
+HELPTEXT += "Option OSCCAL_VALUE=nnn      - set set OSCCAL_VALUE in bootloader\n"
+ifdef OSCCAL_VALUE
+OSCCAL_VALUE_CMD = -DOSCCAL_VALUE=$(OSCCAL_VALUE)
+dummy = FORCE
+endif
+
 
 COMMON_OPTIONS = $(BAUD_RATE_CMD) $(LED_START_FLASHES_CMD) $(BIGBOOT_CMD)
 COMMON_OPTIONS += $(SOFT_UART_CMD) $(LED_DATA_FLASH_CMD) $(LED_CMD) $(SS_CMD)
 COMMON_OPTIONS += $(SUPPORT_EEPROM_CMD) $(LED_START_ON_CMD) $(APPSPM_CMD)
-COMMON_OPTIONS += $(VERSION_CMD)
+COMMON_OPTIONS += $(OSCCAL_VALUE_CMD) $(VERSION_CMD)
 
 #UART is handled separately and only passed for devices with more than one.
 HELPTEXT += "Option UART=n                - use UARTn for communications\n"

--- a/optiboot/bootloaders/optiboot/optiboot.c
+++ b/optiboot/bootloaders/optiboot/optiboot.c
@@ -563,6 +563,10 @@ int main(void) {
   SP=RAMEND;  // This is done by hardware reset
 #endif
 
+#if defined(OSCCAL_VALUE)
+  OSCCAL = OSCCAL_VALUE;
+#endif
+
   /*
    * Protect as much from MCUSR as possible for application
    * and still skip bootloader if not necessary


### PR DESCRIPTION
I use optiboot on Atmega328 with internal oscillator.
Some chip's clock is not accurate, so I fix it in bootloader.