### PR TITLE
Add support for ATmega128rfa1

### DIFF
--- a/optiboot/bootloaders/optiboot/Makefile.extras
+++ b/optiboot/bootloaders/optiboot/Makefile.extras
@@ -95,6 +95,16 @@ atmega32_isp: HFUSE ?= CE
 atmega32_isp: LFUSE ?= BF
 atmega32_isp: isp
 
+#Atmega128RFA1
+HELPTEXT += "target atmega128rfa1  - ATmega128RFA1 (100pin, 128k)\n"
+atmega128rfa1: MCU_TARGET = atmega128rfa1
+atmega128rfa1: CFLAGS += $(COMMON_OPTIONS) -DBIGBOOT $(UART_CMD)
+atmega128rfa1: AVR_FREQ ?= 16000000L
+atmega128rfa1: LDSECTIONS  = -Wl,--section-start=.text=0x1fc00  -Wl,--section-start=.version=0x1fffe
+atmega128rfa1: $(PROGRAM)_atmega128rfa1.hex
+ifndef PRODUCTION
+atmega128rfa1: $(PROGRAM)_atmega128rfa1.lst
+endif
 
 
 #

--- a/optiboot/bootloaders/optiboot/pin_defs.h
+++ b/optiboot/bootloaders/optiboot/pin_defs.h
@@ -316,6 +316,7 @@
 /* Mega support */
 #if    defined(__AVR_ATmega640__)	\
     || defined(__AVR_ATmega1280__)	\
+    || defined(__AVR_ATmega128RFA1__)	\
     || defined(__AVR_ATmega2560__)
 /*------------------------------------------------------------------------ */
 /* Onboard LED is connected to pin PB7 on Arduino Mega */ 


### PR DESCRIPTION
The ATmega128RFA1 is a simmilar to the ATmega1280 but with 16k SRAM and a memory mapped 802.15.4 radio.

It can be found on e.g. the [Microduino CoreRF](https://wiki.microduinoinc.com/Microduino-Module_CoreRF) - and that's the board I flashed optiboot onto.

