### PR TITLE
Allow user defined CFLAGS?

### DIFF
--- a/optiboot/bootloaders/optiboot/Makefile
+++ b/optiboot/bootloaders/optiboot/Makefile
@@ -134,7 +134,7 @@ CC         = $(GCCROOT)avr-gcc
 HELPTEXT += "Option AVR_FREQ=<n>          - Clock rate of AVR CPU\n"
 
 
-override CFLAGS        = -g -Wall $(OPTIMIZE) -mmcu=$(MCU_TARGET) -DF_CPU=$(AVR_FREQ) $(DEFS)
+override CFLAGS        += -g -Wall $(OPTIMIZE) -mmcu=$(MCU_TARGET) -DF_CPU=$(AVR_FREQ) $(DEFS)
 override LDFLAGS       = $(LDSECTIONS) -Wl,--relax -nostartfiles
 
 OBJCOPY        = $(GCCROOT)avr-objcopy


### PR DESCRIPTION
Hi,

To compile for atmega328pb on my distro I have to add "-D__AVR_DEV_LIB_NAME__=m328pb" to CFLAGS. But it appears CFLAGS it clobbered by the Makefile. Changing the syntax would allow custom flags such as this one to be added.

Reference at the bottom of this page: https://github.com/watterott/ATmega328PB-Testing/blob/master/hardware/tools/avr/lib/gcc/avr/4.9.2/device-specs/specs-atmega328pb