### PR TITLE
Calculate memory sections automatically for all targets by Makefile.inc

### DIFF
--- a/optiboot/bootloaders/optiboot/Makefile
+++ b/optiboot/bootloaders/optiboot/Makefile
@@ -39,6 +39,9 @@
 # * This software is licensed under version 2 of the Gnu Public Licence.
 # * See optiboot.c for details.
 
+# include Makefile that contains common definitions of variables
+include Makefile.inc
+
 HELPTEXT = "\n"
 #----------------------------------------------------------------------
 #
@@ -348,9 +351,11 @@ HELPTEXT += "target virboot8      - ATmega8 with virtual boot partition\n"
 virboot8: TARGET = atmega8
 virboot8: MCU_TARGET = atmega8
 virboot8: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION' '-Dsave_vect_num=EE_RDY_vect_num'
-virboot8: AVR_FREQ ?= 16000000L 
+virboot8: AVR_FREQ ?= 16000000L
+virboot8: FLASH_SIZE_KIB = 8
 # Start address of 1D80 allows for size up to 640 bytes, app up to 7552
-virboot8: LDSECTIONS  = -Wl,--section-start=.text=0x1d80 -Wl,--section-start=.version=0x1ffe
+virboot8: BOOT_SECTION_SIZE_B = 640
+virboot8: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
 virboot8: $(PROGRAM)_virboot8.hex
 ifndef PRODUCTION
 virboot8: $(PROGRAM)_virboot8.lst
@@ -362,7 +367,10 @@ virboot328: TARGET = atmega328
 virboot328: MCU_TARGET = atmega328p
 virboot328: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION'
 virboot328: AVR_FREQ ?= 16000000L
-virboot328: LDSECTIONS  = -Wl,--section-start=.text=0x7d80 -Wl,--section-start=.version=0x7ffe
+virboot328: FLASH_SIZE_KIB = 32
+# Start address of 7D80 allows for size up to 640 bytes, app up to 32128
+virboot328: BOOT_SECTION_SIZE_B = 640
+virboot328: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
 virboot328: $(PROGRAM)_virboot328.hex
 ifndef PRODUCTION
 virboot328: $(PROGRAM)_virboot328.lst
@@ -403,11 +411,13 @@ atmega8: TARGET = atmega8
 atmega8: MCU_TARGET = atmega8
 atmega8: CFLAGS += $(COMMON_OPTIONS)
 atmega8: AVR_FREQ ?= 16000000L 
-ifndef BIGBOOT
-atmega8: LDSECTIONS  = -Wl,--section-start=.text=0x1e00 -Wl,--section-start=.version=0x1ffe -Wl,--gc-sections -Wl,--undefined=optiboot_version
-else
-atmega8: LDSECTIONS  = -Wl,--section-start=.text=0x1c00 -Wl,--section-start=.version=0x1ffe -Wl,--gc-sections -Wl,--undefined=optiboot_version
+atmega8: FLASH_SIZE_KIB = 8
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega8: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega8: BOOT_SECTION_SIZE_KIB = 1
 endif
+atmega8: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET) -Wl,--gc-sections -Wl,--undefined=optiboot_version
 atmega8: $(PROGRAM)_atmega8.hex
 ifndef PRODUCTION
 atmega8: $(PROGRAM)_atmega8.lst
@@ -432,11 +442,13 @@ atmega168: TARGET = atmega168
 atmega168: MCU_TARGET = atmega168
 atmega168: CFLAGS += $(COMMON_OPTIONS)
 atmega168: AVR_FREQ ?= 16000000L
-ifndef BIGBOOT
-atmega168: LDSECTIONS  = -Wl,--section-start=.text=0x3e00 -Wl,--section-start=.version=0x3ffe
-else
-atmega168: LDSECTIONS  = -Wl,--section-start=.text=0x3c00 -Wl,--section-start=.version=0x3ffe
+atmega168: FLASH_SIZE_KIB = 16
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega168: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega168: BOOT_SECTION_SIZE_KIB = 1
 endif
+atmega168: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
 atmega168: $(PROGRAM)_atmega168.hex
 ifndef PRODUCTION
 atmega168: $(PROGRAM)_atmega168.lst
@@ -462,12 +474,13 @@ atmega328: TARGET = atmega328
 atmega328: MCU_TARGET = atmega328p
 atmega328: CFLAGS += $(COMMON_OPTIONS)
 atmega328: AVR_FREQ ?= 16000000L
-ifndef BIGBOOT
-atmega328: LDSECTIONS  = -Wl,--section-start=.text=0x7e00 -Wl,--section-start=.version=0x7ffe
-else
-# bigboot version is 1k long; starts earlier
-atmega328: LDSECTIONS  = -Wl,--section-start=.text=0x7c00 -Wl,--section-start=.version=0x7ffe
+atmega328: FLASH_SIZE_KIB = 32
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega328: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega328: BOOT_SECTION_SIZE_KIB = 1
 endif
+atmega328: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
 atmega328: $(PROGRAM)_atmega328.hex
 ifndef PRODUCTION
 atmega328: $(PROGRAM)_atmega328.lst
@@ -494,7 +507,10 @@ atmega328_isp: isp
 atmega1280: MCU_TARGET = atmega1280
 atmega1280: CFLAGS += $(COMMON_OPTIONS) -DBIGBOOT $(UART_CMD)
 atmega1280: AVR_FREQ ?= 16000000L
-atmega1280: LDSECTIONS  = -Wl,--section-start=.text=0x1fc00  -Wl,--section-start=.version=0x1fffe
+atmega1280: FLASH_SIZE_KIB = 128
+## bigboot version is 1024 Bytes long; starts earlier
+atmega1280: BOOT_SECTION_SIZE_KIB = 1
+atmega1280: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
 atmega1280: $(PROGRAM)_atmega1280.hex
 ifndef PRODUCTION
 atmega1280: $(PROGRAM)_atmega1280.lst

--- a/optiboot/bootloaders/optiboot/Makefile
+++ b/optiboot/bootloaders/optiboot/Makefile
@@ -62,8 +62,8 @@ PROGRAM    = optiboot
 export
 
 # defaults
-MCU_TARGET = atmega168
-LDSECTIONS  = -Wl,--section-start=.text=0x3e00 -Wl,--section-start=.version=0x3ffe
+default:
+	"$(MAKE)" atmega168
 
 # Build environments
 # Start of some ugly makefile-isms to allow optiboot to be built

--- a/optiboot/bootloaders/optiboot/Makefile
+++ b/optiboot/bootloaders/optiboot/Makefile
@@ -355,7 +355,7 @@ virboot8: AVR_FREQ ?= 16000000L
 virboot8: FLASH_SIZE_KIB = 8
 # Start address of 1D80 allows for size up to 640 bytes, app up to 7552
 virboot8: BOOT_SECTION_SIZE_B = 640
-virboot8: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
+virboot8: LDSECTIONS = $(COMMON_SECTIONS)
 virboot8: $(PROGRAM)_virboot8.hex
 ifndef PRODUCTION
 virboot8: $(PROGRAM)_virboot8.lst
@@ -370,7 +370,7 @@ virboot328: AVR_FREQ ?= 16000000L
 virboot328: FLASH_SIZE_KIB = 32
 # Start address of 7D80 allows for size up to 640 bytes, app up to 32128
 virboot328: BOOT_SECTION_SIZE_B = 640
-virboot328: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
+virboot328: LDSECTIONS = $(COMMON_SECTIONS)
 virboot328: $(PROGRAM)_virboot328.hex
 ifndef PRODUCTION
 virboot328: $(PROGRAM)_virboot328.lst
@@ -417,7 +417,7 @@ atmega8: BOOT_SECTION_SIZE_B = 512
 else ## bigboot version is 1024 Bytes long; starts earlier
 atmega8: BOOT_SECTION_SIZE_KIB = 1
 endif
-atmega8: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET) -Wl,--gc-sections -Wl,--undefined=optiboot_version
+atmega8: LDSECTIONS = $(COMMON_SECTIONS) -Wl,--gc-sections -Wl,--undefined=optiboot_version
 atmega8: $(PROGRAM)_atmega8.hex
 ifndef PRODUCTION
 atmega8: $(PROGRAM)_atmega8.lst
@@ -448,7 +448,7 @@ atmega168: BOOT_SECTION_SIZE_B = 512
 else ## bigboot version is 1024 Bytes long; starts earlier
 atmega168: BOOT_SECTION_SIZE_KIB = 1
 endif
-atmega168: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
+atmega168: LDSECTIONS = $(COMMON_SECTIONS)
 atmega168: $(PROGRAM)_atmega168.hex
 ifndef PRODUCTION
 atmega168: $(PROGRAM)_atmega168.lst
@@ -480,7 +480,7 @@ atmega328: BOOT_SECTION_SIZE_B = 512
 else ## bigboot version is 1024 Bytes long; starts earlier
 atmega328: BOOT_SECTION_SIZE_KIB = 1
 endif
-atmega328: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
+atmega328: LDSECTIONS = $(COMMON_SECTIONS)
 atmega328: $(PROGRAM)_atmega328.hex
 ifndef PRODUCTION
 atmega328: $(PROGRAM)_atmega328.lst
@@ -510,7 +510,7 @@ atmega1280: AVR_FREQ ?= 16000000L
 atmega1280: FLASH_SIZE_KIB = 128
 ## bigboot version is 1024 Bytes long; starts earlier
 atmega1280: BOOT_SECTION_SIZE_KIB = 1
-atmega1280: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
+atmega1280: LDSECTIONS = $(COMMON_SECTIONS)
 atmega1280: $(PROGRAM)_atmega1280.hex
 ifndef PRODUCTION
 atmega1280: $(PROGRAM)_atmega1280.lst

--- a/optiboot/bootloaders/optiboot/Makefile.1284
+++ b/optiboot/bootloaders/optiboot/Makefile.1284
@@ -5,6 +5,9 @@
 # * This software is licensed under version 2 of the Gnu Public Licence.
 # * See optiboot.c for details.
 
+# include Makefile that contains common definitions of variables
+include Makefile.inc
+
 # Chip level targets
 #
 HELPTEXT += "target atmega644p    - ATmega644p\n"
@@ -12,7 +15,10 @@ atmega644p: TARGET = atmega644p
 atmega644p: MCU_TARGET = atmega644p
 atmega644p: CFLAGS += $(COMMON_OPTIONS) -DBIGBOOT
 atmega644p: AVR_FREQ ?= 16000000L
-atmega644p: LDSECTIONS  = -Wl,--section-start=.text=0xfc00 -Wl,--section-start=.version=0xfffe
+atmega644p: FLASH_SIZE_KIB = 64
+## bigboot version is 1024 Bytes long; starts earlier
+atmega644p: BOOT_SECTION_SIZE_KIB = 1
+atmega644p: LDSECTIONS = $(COMMON_SECTIONS)
 atmega644p: CFLAGS += $(UART_CMD)
 atmega644p: $(PROGRAM)_atmega644p.hex
 ifndef PRODUCTION
@@ -24,7 +30,11 @@ atmega1284: TARGET = atmega1284p
 atmega1284: MCU_TARGET = atmega1284p
 atmega1284: CFLAGS += $(COMMON_OPTIONS) -DBIGBOOT
 atmega1284: AVR_FREQ ?= 16000000L
-atmega1284: LDSECTIONS  = -Wl,--section-start=.text=0x1fc00 -Wl,--section-start=.version=0x1fffe
+#atmega1284: LDSECTIONS  = -Wl,--section-start=.text=0x1fc00 -Wl,--section-start=.version=0x1fffe
+atmega1284: FLASH_SIZE_KIB = 16
+## bigboot version is 1024 Bytes long; starts earlier
+atmega1284: BOOT_SECTION_SIZE_KIB = 1
+atmega1284: LDSECTIONS = $(COMMON_SECTIONS)
 atmega1284: CFLAGS += $(UART_CMD)
 atmega1284: $(PROGRAM)_atmega1284p.hex
 ifndef PRODUCTION

--- a/optiboot/bootloaders/optiboot/Makefile.2560
+++ b/optiboot/bootloaders/optiboot/Makefile.2560
@@ -5,6 +5,9 @@
 # * This software is licensed under version 2 of the Gnu Public Licence.
 # * See optiboot.c for details.
 
+# include Makefile that contains common definitions of variables
+include Makefile.inc
+
 # Chip level targets
 #
 HELPTEXT += "target atmega2560    - ATmega2560p (100pin, 256k)\n"
@@ -12,7 +15,10 @@ atmega2560: TARGET = atmega2560
 atmega2560: MCU_TARGET = atmega2560
 atmega2560: CFLAGS += $(COMMON_OPTIONS) -DBIGBOOT
 atmega2560: AVR_FREQ ?= 16000000L
-atmega2560: LDSECTIONS  = -Wl,--section-start=.text=0x3fc00 -Wl,--section-start=.version=0x3fffe
+atmega2560: FLASH_SIZE_KIB = 256
+## bigboot version is 1024 Bytes long; starts earlier
+atmega2560: BOOT_SECTION_SIZE_KIB = 1
+atmega2560: LDSECTIONS = $(COMMON_SECTIONS)
 atmega2560: CFLAGS += $(UART_CMD)
 atmega2560: $(PROGRAM)_atmega2560.hex
 ifndef PRODUCTION

--- a/optiboot/bootloaders/optiboot/Makefile.extras
+++ b/optiboot/bootloaders/optiboot/Makefile.extras
@@ -6,6 +6,9 @@
 # * See optiboot.c for details.
 #
 
+# include Makefile that contains common definitions of variables
+include Makefile.inc
+
 #
 # Extra chips (maybe) supported by optiboot
 # Note that these are usually only minimally tested.
@@ -19,7 +22,13 @@ atmega88: TARGET = atmega88
 atmega88: MCU_TARGET = atmega88
 atmega88: CFLAGS += $(COMMON_OPTIONS)
 atmega88: AVR_FREQ ?= 16000000L 
-atmega88: LDSECTIONS  = -Wl,--section-start=.text=0x1e00 -Wl,--section-start=.version=0x1ffe -Wl,--gc-sections -Wl,--undefined=optiboot_version
+atmega88: FLASH_SIZE_KIB = 8
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega88: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega88: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega88: LDSECTIONS = $(COMMON_SECTIONS) -Wl,--gc-sections -Wl,--undefined=optiboot_version
 atmega88: $(PROGRAM)_atmega88.hex
 atmega88: $(PROGRAM)_atmega88.lst
 
@@ -82,7 +91,13 @@ atmega32: TARGET = atmega32
 atmega32: MCU_TARGET = atmega32
 atmega32: CFLAGS += $(COMMON_OPTIONS)
 atmega32: AVR_FREQ ?= 11059200L
-atmega32: LDSECTIONS  = -Wl,--section-start=.text=0x7e00 -Wl,--section-start=.version=0x7ffe
+atmega32: FLASH_SIZE_KIB = 32
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega32: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega32: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega32: LDSECTIONS = $(COMMON_SECTIONS)
 atmega32: $(PROGRAM)_atmega32.hex
 atmega32: $(PROGRAM)_atmega32.lst
 
@@ -100,7 +115,10 @@ HELPTEXT += "target atmega128rfa1  - ATmega128RFA1 (100pin, 128k)\n"
 atmega128rfa1: MCU_TARGET = atmega128rfa1
 atmega128rfa1: CFLAGS += $(COMMON_OPTIONS) -DBIGBOOT $(UART_CMD)
 atmega128rfa1: AVR_FREQ ?= 16000000L
-atmega128rfa1: LDSECTIONS  = -Wl,--section-start=.text=0x1fc00  -Wl,--section-start=.version=0x1fffe
+atmega128rfa1: FLASH_SIZE_KIB = 128
+## bigboot version is 1024 Bytes long; starts earlier
+atmega128rfa1: BOOT_SECTION_SIZE_KIB = 1
+atmega128rfa1: LDSECTIONS = $(COMMON_SECTIONS)
 atmega128rfa1: $(PROGRAM)_atmega128rfa1.hex
 ifndef PRODUCTION
 atmega128rfa1: $(PROGRAM)_atmega128rfa1.lst

--- a/optiboot/bootloaders/optiboot/Makefile.extras
+++ b/optiboot/bootloaders/optiboot/Makefile.extras
@@ -90,7 +90,7 @@ HELPTEXT += "target atmega32      - ATmega32 (40pin, 32k)\n"
 atmega32: TARGET = atmega32
 atmega32: MCU_TARGET = atmega32
 atmega32: CFLAGS += $(COMMON_OPTIONS)
-atmega32: AVR_FREQ ?= 11059200L
+atmega32: AVR_FREQ ?= 16000000L
 atmega32: FLASH_SIZE_KIB = 32
 ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
 atmega32: BOOT_SECTION_SIZE_B = 512

--- a/optiboot/bootloaders/optiboot/Makefile.inc
+++ b/optiboot/bootloaders/optiboot/Makefile.inc
@@ -11,20 +11,25 @@ endif
 
 # function to calculate hex addresses from size given as decimal
 #CALC_ADDRESS_IN_HEX = $(printf '%s=sh' "0x%x" $$(($(1))))
-#CALC_ADDRESS_IN_HEX = $(shell printf "0x%x" $$(($(1))))
-CALC_ADDRESS_IN_HEX = $(shell printf "0x%06x" $$(($(1))))
+CALC_ADDRESS_IN_HEX = $(shell printf "0x%x" $$(($(1))))
 
 # preset variables with zero to avoid error messages
 BOOT_SECTION_SIZE_KIB  ?= 0
 FLASH_SIZE_KIB         ?= 0
 
 # functions to convert KibIByte (KIB) to Byte (B)
-BOOT_SECTION_SIZE_B  = ($(BOOT_SECTION_SIZE_KIB) * 1024)
-FLASH_SIZE_B         = ($(FLASH_SIZE_KIB) * 1024)
+BOOT_SECTION_SIZE_B  ?= ($(BOOT_SECTION_SIZE_KIB) * 1024)
+FLASH_SIZE_B         ?= ($(FLASH_SIZE_KIB) * 1024)
 
 # formulas to calculate addresses of memory sections
-BOOT_SEC_OFFSET      = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_SIZE_B)) - ($(BOOT_SECTION_SIZE_B)) )
-TEXT_SEC_OFFSET      = $(BOOT_SEC_OFFSET)
-VERSION_SEC_OFFSET   = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_SIZE_B)) )
-FLASHEND             = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_SIZE_B) - 1) )
+BOOT_SEC_OFFSET      ?= $(call CALC_ADDRESS_IN_HEX, ($(FLASH_SIZE_B)) - ($(BOOT_SECTION_SIZE_B)) )
+TEXT_SEC_OFFSET      ?= $(BOOT_SEC_OFFSET)
+VERSION_SEC_OFFSET   ?= $(call CALC_ADDRESS_IN_HEX, ($(FLASH_SIZE_B)) )
+FLASH_END_OFFSET     ?= $(call CALC_ADDRESS_IN_HEX, ($(FLASH_SIZE_B) - 1) )
 
+
+
+
+
+# the memory sections used by multiple targets
+COMMON_SECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)

--- a/optiboot/bootloaders/optiboot/Makefile.inc
+++ b/optiboot/bootloaders/optiboot/Makefile.inc
@@ -1,0 +1,30 @@
+# Makefile that contains common definitions of variables
+
+
+# use bash if installed on system else use the shell the script is called with
+# to remove error message /bin/sh: 1: arithmetic expression: expecting primary: ""
+# when invoking $(shell printf "0x%x" $$(($(1)))) or $(shell printf "0x%x" $$(($(1))))
+ifeq ($(shell test -s /bin/bash && echo -n yes), yes)
+SHELL=/bin/bash
+endif
+
+
+# function to calculate hex addresses from size given as decimal
+#CALC_ADDRESS_IN_HEX = $(printf '%s=sh' "0x%x" $$(($(1))))
+#CALC_ADDRESS_IN_HEX = $(shell printf "0x%x" $$(($(1))))
+CALC_ADDRESS_IN_HEX = $(shell printf "0x%06x" $$(($(1))))
+
+# preset variables with zero to avoid error messages
+BOOT_SECTION_SIZE_KIB  ?= 0
+FLASH_SIZE_KIB         ?= 0
+
+# functions to convert KibIByte (KIB) to Byte (B)
+BOOT_SECTION_SIZE_B  = ($(BOOT_SECTION_SIZE_KIB) * 1024)
+FLASH_SIZE_B         = ($(FLASH_SIZE_KIB) * 1024)
+
+# formulas to calculate addresses of memory sections
+BOOT_SEC_OFFSET      = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_SIZE_B)) - ($(BOOT_SECTION_SIZE_B)) )
+TEXT_SEC_OFFSET      = $(BOOT_SEC_OFFSET)
+VERSION_SEC_OFFSET   = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_SIZE_B)) )
+FLASHEND             = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_SIZE_B) - 1) )
+

--- a/optiboot/bootloaders/optiboot/Makefile.inc
+++ b/optiboot/bootloaders/optiboot/Makefile.inc
@@ -22,19 +22,19 @@ BOOT_SECTION_SIZE_B   = ($(BOOT_SECTION_SIZE_KIB) * 1024)
 FLASH_SIZE_B          = ($(FLASH_SIZE_KIB) * 1024)
 
 # formulas to calculate addresses of memory sections
-FLASH_START_OFFSET    = $(call CALC_ADDRESS_IN_HEX, (0) )
-FLASH_END_OFFSET      = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_SIZE_B) - 1) )
+FLASH_START_OFFSET    = (0)
+FLASH_END_OFFSET      = ($(FLASH_SIZE_B) - 1)
 
 # mega0 family (optiboot_x)
 ifdef BOOTSECTION_FIRST
-  APP_START_OFFSET      = $(call CALC_ADDRESS_IN_HEX, ($(BOOT_SECTION_SIZE_B)) )
-  APP_END_OFFSET        = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_END_OFFSET)) )
+  APP_START_OFFSET      = ($(BOOT_SECTION_SIZE_B))
+  APP_END_OFFSET        = ($(FLASH_END_OFFSET))
 
-  BOOT_START_OFFSET     = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_START_OFFSET)) )
-  BOOT_END_OFFSET       = $(call CALC_ADDRESS_IN_HEX, ($(BOOT_SECTION_SIZE_B) - 1) )
+  BOOT_START_OFFSET     = ($(FLASH_START_OFFSET)) )
+  BOOT_END_OFFSET       = ($(BOOT_SECTION_SIZE_B) - 1))
 
   # calculate section offsets
-  BOOT_SEC_OFFSET       = $(BOOT_START_OFFSET)
+  BOOT_SEC_OFFSET       = $(call CALC_ADDRESS_IN_HEX, $(BOOT_START_OFFSET) )
   TEXT_SEC_OFFSET       = $(BOOT_SEC_OFFSET)
   VERSION_SEC_OFFSET    = $(call CALC_ADDRESS_IN_HEX, ($(BOOT_END_OFFSET) - 1) )
   ## space for further formulas
@@ -48,14 +48,14 @@ ifdef BOOTSECTION_FIRST
 
 # most other avr's (optiboot)
 else # BOOTSECTION_AFTER
-  APP_START_OFFSET      = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_START_OFFSET)) )
-  APP_END_OFFSET        = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_END_OFFSET)) - ($(BOOT_SECTION_SIZE_B)) )
+  APP_START_OFFSET      = ($(FLASH_START_OFFSET))
+  APP_END_OFFSET        = ($(FLASH_END_OFFSET)) - ($(BOOT_SECTION_SIZE_B))
 
-  BOOT_START_OFFSET     = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_SIZE_B)) - ($(BOOT_SECTION_SIZE_B)) )
-  BOOT_END_OFFSET       = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_END_OFFSET)) )
+  BOOT_START_OFFSET     = ($(FLASH_SIZE_B) - $(BOOT_SECTION_SIZE_B))
+  BOOT_END_OFFSET       = ($(FLASH_END_OFFSET))
 
   # calculate section offsets
-  BOOT_SEC_OFFSET       = $(BOOT_START_OFFSET)
+  BOOT_SEC_OFFSET       = $(call CALC_ADDRESS_IN_HEX, $(BOOT_START_OFFSET) )
   TEXT_SEC_OFFSET       = $(BOOT_SEC_OFFSET)
   VERSION_SEC_OFFSET    = $(call CALC_ADDRESS_IN_HEX, ($(BOOT_END_OFFSET) - 1) )
   ## space for further formulas

--- a/optiboot/bootloaders/optiboot/Makefile.inc
+++ b/optiboot/bootloaders/optiboot/Makefile.inc
@@ -18,18 +18,52 @@ BOOT_SECTION_SIZE_KIB  ?= 0
 FLASH_SIZE_KIB         ?= 0
 
 # functions to convert KibIByte (KIB) to Byte (B)
-BOOT_SECTION_SIZE_B  ?= ($(BOOT_SECTION_SIZE_KIB) * 1024)
-FLASH_SIZE_B         ?= ($(FLASH_SIZE_KIB) * 1024)
+BOOT_SECTION_SIZE_B   = ($(BOOT_SECTION_SIZE_KIB) * 1024)
+FLASH_SIZE_B          = ($(FLASH_SIZE_KIB) * 1024)
 
 # formulas to calculate addresses of memory sections
-BOOT_SEC_OFFSET      ?= $(call CALC_ADDRESS_IN_HEX, ($(FLASH_SIZE_B)) - ($(BOOT_SECTION_SIZE_B)) )
-TEXT_SEC_OFFSET      ?= $(BOOT_SEC_OFFSET)
-VERSION_SEC_OFFSET   ?= $(call CALC_ADDRESS_IN_HEX, ($(FLASH_SIZE_B)) )
-FLASH_END_OFFSET     ?= $(call CALC_ADDRESS_IN_HEX, ($(FLASH_SIZE_B) - 1) )
+FLASH_START_OFFSET    = $(call CALC_ADDRESS_IN_HEX, (0) )
+FLASH_END_OFFSET      = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_SIZE_B) - 1) )
+
+# mega0 family (optiboot_x)
+ifdef BOOTSECTION_FIRST
+  APP_START_OFFSET      = $(call CALC_ADDRESS_IN_HEX, ($(BOOT_SECTION_SIZE_B)) )
+  APP_END_OFFSET        = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_END_OFFSET)) )
+
+  BOOT_START_OFFSET     = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_START_OFFSET)) )
+  BOOT_END_OFFSET       = $(call CALC_ADDRESS_IN_HEX, ($(BOOT_SECTION_SIZE_B) - 1) )
+
+  # calculate section offsets
+  BOOT_SEC_OFFSET       = $(BOOT_START_OFFSET)
+  TEXT_SEC_OFFSET       = $(BOOT_SEC_OFFSET)
+  VERSION_SEC_OFFSET    = $(call CALC_ADDRESS_IN_HEX, ($(BOOT_END_OFFSET) - 1) )
+  ## space for further formulas
 
 
+  # the memory sections used by multiple targets
+  COMMON_SECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) \
+                    -Wl,--section-start=.application=$(APP_START_OFFSET) \
+                    -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
+  ## enter further sections here
+
+# most other avr's (optiboot)
+else # BOOTSECTION_AFTER
+  APP_START_OFFSET      = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_START_OFFSET)) )
+  APP_END_OFFSET        = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_END_OFFSET)) - ($(BOOT_SECTION_SIZE_B)) )
+
+  BOOT_START_OFFSET     = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_SIZE_B)) - ($(BOOT_SECTION_SIZE_B)) )
+  BOOT_END_OFFSET       = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_END_OFFSET)) )
+
+  # calculate section offsets
+  BOOT_SEC_OFFSET       = $(BOOT_START_OFFSET)
+  TEXT_SEC_OFFSET       = $(BOOT_SEC_OFFSET)
+  VERSION_SEC_OFFSET    = $(call CALC_ADDRESS_IN_HEX, ($(BOOT_END_OFFSET) - 1) )
+  ## space for further formulas
 
 
+  # the memory sections used by multiple targets
+  COMMON_SECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) \
+                    -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
+  ## enter further sections here
 
-# the memory sections used by multiple targets
-COMMON_SECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
+endif

--- a/optiboot/bootloaders/optiboot/Makefile.mcudude
+++ b/optiboot/bootloaders/optiboot/Makefile.mcudude
@@ -7,6 +7,9 @@
 # * of AVR_FREQ, BAUD_RATE, and UART are built by a shell script.
 # */
 
+# include Makefile that contains common definitions of variables
+include Makefile.inc
+
 HELPTEXT += "\n target atmega1280    - ATmega1280 (100pin, 128k)\n"
 HELPTEXT += "target atmega88*     - Atmega88, ATmega88P, ATmega88PB\n"
 HELPTEXT += "target atmega16, atmega32, atmega64 - 40pin ATmegas\n"
@@ -26,6 +29,13 @@ atmega16: MCU_TARGET = atmega16
 atmega16: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega16: AVR_FREQ ?= 16000000L
 atmega16: LDSECTIONS = -Wl,--section-start=.text=0x3e00 -Wl,--section-start=.version=0x3ffe
+atmega16: FLASH_SIZE_KIB = 16
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega16: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega16: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega16: LDSECTIONS = $(COMMON_SECTIONS)
 atmega16: $(PROGRAM)_atmega16_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega16: $(PROGRAM)_atmega16_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -37,7 +47,11 @@ atmega64: TARGET = atmega64
 atmega64: MCU_TARGET = atmega64
 atmega64: CFLAGS += $(COMMON_OPTIONS) -DBIGBOOT $(UART_CMD)
 atmega64: AVR_FREQ ?= 16000000L
-atmega64: LDSECTIONS = -Wl,--section-start=.text=0xfc00 -Wl,--section-start=.version=0xfffe
+#atmega64: LDSECTIONS = -Wl,--section-start=.text=0xfc00 -Wl,--section-start=.version=0xfffe
+atmega64: FLASH_SIZE_KIB = 64
+## bigboot version is 1024 Bytes long; starts earlier
+atmega64: BOOT_SECTION_SIZE_KIB = 1
+atmega64: LDSECTIONS = $(COMMON_SECTIONS)
 atmega64: $(PROGRAM)_atmega64_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega64: $(PROGRAM)_atmega64_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -49,19 +63,31 @@ atmega88p: TARGET = atmega88p
 atmega88p: MCU_TARGET = atmega88p
 atmega88p: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega88p: AVR_FREQ ?= 16000000L 
-atmega88p: LDSECTIONS = -Wl,--section-start=.text=0x1e00 -Wl,--section-start=.version=0x1ffe -Wl,--gc-sections -Wl,--undefined=optiboot_version
+atmega88p: FLASH_SIZE_KIB = 8
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega88p: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega88p: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega88p: LDSECTIONS = $(COMMON_SECTIONS) -Wl,--gc-sections -Wl,--undefined=optiboot_version
 atmega88p: $(PROGRAM)_atmega88p_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega88p: $(PROGRAM)_atmega88p_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
 endif
 atmega88pa: atmega88p
 
-#ATmega8PB
+#ATmega88PB
 atmega88pb: TARGET = atmega88pb
 atmega88pb: MCU_TARGET = atmega88pb
 atmega88pb: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega88pb: AVR_FREQ ?= 16000000L
-atmega88pb: LDSECTIONS = -Wl,--section-start=.text=0x1e00 -Wl,--section-start=.version=0x1ffe -Wl,--gc-sections -Wl,--undefined=optiboot_version
+atmega88pb: FLASH_SIZE_KIB = 8
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega88pb: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega88pb: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega88pb: LDSECTIONS = $(COMMON_SECTIONS) -Wl,--gc-sections -Wl,--undefined=optiboot_version
 atmega88pb: $(PROGRAM)_atmega88pb_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega88pb: $(PROGRAM)_atmega88pb_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -72,7 +98,10 @@ atmega128: TARGET = atmega128
 atmega128: MCU_TARGET = atmega128
 atmega128: CFLAGS += $(COMMON_OPTIONS) -DBIGBOOT $(UART_CMD)
 atmega128: AVR_FREQ ?= 16000000L
-atmega128: LDSECTIONS = -Wl,--section-start=.text=0x1fc00 -Wl,--section-start=.version=0x1fffe
+atmega128: FLASH_SIZE_KIB = 128
+## bigboot version is 1024 Bytes long; starts earlier
+atmega128: BOOT_SECTION_SIZE_KIB = 1
+atmega128: LDSECTIONS = $(COMMON_SECTIONS)
 atmega128: $(PROGRAM)_atmega128_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega128: $(PROGRAM)_atmega128_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -84,7 +113,13 @@ atmega162: TARGET = atmega162
 atmega162: MCU_TARGET = atmega162
 atmega162: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega162: AVR_FREQ ?= 16000000L
-atmega162: LDSECTIONS = -Wl,--section-start=.text=0x3e00 -Wl,--section-start=.version=0x3ffe
+atmega162: FLASH_SIZE_KIB = 16
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega162: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega162: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega162: LDSECTIONS = $(COMMON_SECTIONS)
 atmega162: $(PROGRAM)_atmega162_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega162: $(PROGRAM)_atmega162_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -95,7 +130,13 @@ atmega164a: TARGET = atmega164a
 atmega164a: MCU_TARGET = atmega164a
 atmega164a: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega164a: AVR_FREQ ?= 16000000L
-atmega164a: LDSECTIONS = -Wl,--section-start=.text=0x3e00 -Wl,--section-start=.version=0x3ffe
+atmega164a: FLASH_SIZE_KIB = 16
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega164a: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega164a: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega164a: LDSECTIONS = $(COMMON_SECTIONS)
 atmega164a: $(PROGRAM)_atmega164a_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega164a: $(PROGRAM)_atmega164a_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -107,7 +148,13 @@ atmega164p: TARGET = atmega164p
 atmega164p: MCU_TARGET = atmega164p
 atmega164p: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega164p: AVR_FREQ ?= 16000000L
-atmega164p: LDSECTIONS = -Wl,--section-start=.text=0x3e00 -Wl,--section-start=.version=0x3ffe
+atmega164p: FLASH_SIZE_KIB = 16
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega164p: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega164p: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega164p: LDSECTIONS = $(COMMON_SECTIONS)
 atmega164p: $(PROGRAM)_atmega164p_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega164p: $(PROGRAM)_atmega164p_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -119,7 +166,13 @@ atmega164pa: atmega164p
 #atmega168: MCU_TARGET = atmega168
 #atmega168: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 #atmega168: AVR_FREQ ?= 16000000L 
-#atmega168: LDSECTIONS = -Wl,--section-start=.text=0x3e00 -Wl,--section-start=.version=0x3ffe
+#atmega168: FLASH_SIZE_KIB = 16
+#ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+#atmega168: BOOT_SECTION_SIZE_B = 512
+#else ## bigboot version is 1024 Bytes long; starts earlier
+#atmega168: BOOT_SECTION_SIZE_KIB = 1
+#endif
+#atmega168: LDSECTIONS = $(COMMON_SECTIONS)
 #atmega168: $(PROGRAM)_atmega168_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 #ifndef PRODUCTION
 #atmega168: $(PROGRAM)_atmega168_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -131,7 +184,13 @@ atmega168p: TARGET = atmega168p
 atmega168p: MCU_TARGET = atmega168p
 atmega168p: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega168p: AVR_FREQ ?= 16000000L 
-atmega168p: LDSECTIONS = -Wl,--section-start=.text=0x3e00 -Wl,--section-start=.version=0x3ffe
+atmega168p: FLASH_SIZE_KIB = 16
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega168p: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega168p: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega168p: LDSECTIONS = $(COMMON_SECTIONS)
 atmega168p: $(PROGRAM)_atmega168p_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega168p: $(PROGRAM)_atmega168p_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -143,7 +202,13 @@ atmega168pb: TARGET = atmega168pb
 atmega168pb: MCU_TARGET = atmega168pb
 atmega168pb: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega168pb: AVR_FREQ ?= 16000000L 
-atmega168pb: LDSECTIONS = -Wl,--section-start=.text=0x3e00 -Wl,--section-start=.version=0x3ffe
+atmega168pb: FLASH_SIZE_KIB = 16
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega168pb: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega168pb: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega168pb: LDSECTIONS = $(COMMON_SECTIONS)
 atmega168pb: $(PROGRAM)_atmega168pb_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega168pb: $(PROGRAM)_atmega168pb_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -154,7 +219,13 @@ atmega169: TARGET = atmega169
 atmega169: MCU_TARGET = atmega169
 atmega169: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega169: AVR_FREQ ?= 16000000L
-atmega169: LDSECTIONS = -Wl,--section-start=.text=0x3e00 -Wl,--section-start=.version=0x3ffe
+atmega169: FLASH_SIZE_KIB = 16
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega169: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega169: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega169: LDSECTIONS = $(COMMON_SECTIONS)
 atmega169: $(PROGRAM)_atmega169_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega169: $(PROGRAM)_atmega169_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -166,7 +237,13 @@ atmega169p: TARGET = atmega169p
 atmega169p: MCU_TARGET = atmega169p
 atmega169p: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega169p: AVR_FREQ ?= 16000000L
-atmega169p: LDSECTIONS = -Wl,--section-start=.text=0x3e00 -Wl,--section-start=.version=0x3ffe
+atmega169p: FLASH_SIZE_KIB = 16
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega169p: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega169p: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega169p: LDSECTIONS = $(COMMON_SECTIONS)
 atmega169p: $(PROGRAM)_atmega169p_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega169p: $(PROGRAM)_atmega169p_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -178,7 +255,13 @@ atmega324a: TARGET = atmega324a
 atmega324a: MCU_TARGET = atmega324a
 atmega324a: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega324a: AVR_FREQ ?= 16000000L
-atmega324a: LDSECTIONS = -Wl,--section-start=.text=0x7e00 -Wl,--section-start=.version=0x7ffe
+atmega324a: FLASH_SIZE_KIB = 32
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega324a: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega324a: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega324a: LDSECTIONS = $(COMMON_SECTIONS)
 atmega324a: $(PROGRAM)_atmega324a_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega324a: $(PROGRAM)_atmega324a_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -190,7 +273,13 @@ atmega324p: TARGET = atmega324p
 atmega324p: MCU_TARGET = atmega324p
 atmega324p: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega324p: AVR_FREQ ?= 16000000L
-atmega324p: LDSECTIONS = -Wl,--section-start=.text=0x7e00 -Wl,--section-start=.version=0x7ffe
+atmega324p: FLASH_SIZE_KIB = 32
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega324p: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega324p: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega324p: LDSECTIONS = $(COMMON_SECTIONS)
 atmega324p: $(PROGRAM)_atmega324p_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega324p: $(PROGRAM)_atmega324p_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -201,7 +290,13 @@ atmega324pa: TARGET = atmega324pa
 atmega324pa: MCU_TARGET = atmega324pa
 atmega324pa: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega324pa: AVR_FREQ ?= 16000000L
-atmega324pa: LDSECTIONS = -Wl,--section-start=.text=0x7e00 -Wl,--section-start=.version=0x7ffe
+atmega324pa: FLASH_SIZE_KIB = 32
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega324pa: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega324pa: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega324pa: LDSECTIONS = $(COMMON_SECTIONS)
 atmega324pa: $(PROGRAM)_atmega324pa_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega324pa: $(PROGRAM)_atmega324pa_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -212,7 +307,13 @@ atmega324pb: TARGET = atmega324pb
 atmega324pb: MCU_TARGET = atmega324pb
 atmega324pb: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega324pb: AVR_FREQ ?= 16000000L
-atmega324pb: LDSECTIONS = -Wl,--section-start=.text=0x7e00 -Wl,--section-start=.version=0x7ffe
+atmega324pb: FLASH_SIZE_KIB = 32
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega324pb: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega324pb: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega324pb: LDSECTIONS = $(COMMON_SECTIONS)
 atmega324pb: $(PROGRAM)_atmega324pb_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega324pb: $(PROGRAM)_atmega324pb_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -223,7 +324,13 @@ atmega328pb: TARGET = atmega328pb
 atmega328pb: MCU_TARGET = atmega328pb
 atmega328pb: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega328pb: AVR_FREQ ?= 16000000L
-atmega328pb: LDSECTIONS = -Wl,--section-start=.text=0x7e00 -Wl,--section-start=.version=0x7ffe
+atmega328pb: FLASH_SIZE_KIB = 32
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega328pb: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega328pb: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega328pb: LDSECTIONS = $(COMMON_SECTIONS)
 atmega328pb: $(PROGRAM)_atmega328pb_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega328pb: $(PROGRAM)_atmega328pb_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -234,7 +341,13 @@ atmega329: TARGET = atmega329
 atmega329: MCU_TARGET = atmega329
 atmega329: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega329: AVR_FREQ ?= 16000000L
-atmega329: LDSECTIONS = -Wl,--section-start=.text=0x7e00 -Wl,--section-start=.version=0x7ffe
+atmega329: FLASH_SIZE_KIB = 32
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega329: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega329: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega329: LDSECTIONS = $(COMMON_SECTIONS)
 atmega329: $(PROGRAM)_atmega329_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega329: $(PROGRAM)_atmega329_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -258,7 +371,10 @@ atmega640: TARGET = atmega640
 atmega640: MCU_TARGET = atmega640
 atmega640: CFLAGS += $(COMMON_OPTIONS) -DBIGBOOT $(UART_CMD)
 atmega640: AVR_FREQ ?= 16000000L
-atmega640: LDSECTIONS = -Wl,--section-start=.text=0xfc00 -Wl,--section-start=.version=0xfffe
+atmega640: FLASH_SIZE_KIB = 64
+## bigboot version is 1024 Bytes long; starts earlier
+atmega640: BOOT_SECTION_SIZE_KIB = 1
+atmega640: LDSECTIONS = $(COMMON_SECTIONS)
 atmega640: $(PROGRAM)_atmega640_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega640: $(PROGRAM)_atmega640_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -269,7 +385,10 @@ atmega649: TARGET = atmega649
 atmega649: MCU_TARGET = atmega649
 atmega649: CFLAGS += $(COMMON_OPTIONS) -DBIGBOOT $(UART_CMD)
 atmega649: AVR_FREQ ?= 16000000L
-atmega649: LDSECTIONS = -Wl,--section-start=.text=0xfc00 -Wl,--section-start=.version=0xfffe
+atmega649: FLASH_SIZE_KIB = 64
+## bigboot version is 1024 Bytes long; starts earlier
+atmega649: BOOT_SECTION_SIZE_KIB = 1
+atmega649: LDSECTIONS = $(COMMON_SECTIONS)
 atmega649: $(PROGRAM)_atmega649_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega649: $(PROGRAM)_atmega649_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -280,7 +399,10 @@ atmega649p: TARGET = atmega649p
 atmega649p: MCU_TARGET = atmega649p
 atmega649p: CFLAGS += $(COMMON_OPTIONS) -DBIGBOOT $(UART_CMD)
 atmega649p: AVR_FREQ ?= 16000000L
-atmega649p: LDSECTIONS = -Wl,--section-start=.text=0xfc00 -Wl,--section-start=.version=0xfffe
+atmega649p: FLASH_SIZE_KIB = 64
+## bigboot version is 1024 Bytes long; starts earlier
+atmega649p: BOOT_SECTION_SIZE_KIB = 1
+atmega649p: LDSECTIONS = $(COMMON_SECTIONS)
 atmega649p: $(PROGRAM)_atmega649p_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega649p: $(PROGRAM)_atmega649p_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -291,7 +413,10 @@ atmega1281: TARGET = atmega1281
 atmega1281: MCU_TARGET = atmega1281
 atmega1281: CFLAGS += $(COMMON_OPTIONS) -DBIGBOOT $(UART_CMD)
 atmega1281: AVR_FREQ ?= 16000000L
-atmega1281: LDSECTIONS = -Wl,--section-start=.text=0x1fc00 -Wl,--section-start=.version=0x1fffe
+atmega1281: FLASH_SIZE_KIB = 128
+## bigboot version is 1024 Bytes long; starts earlier
+atmega1281: BOOT_SECTION_SIZE_KIB = 1
+atmega1281: LDSECTIONS = $(COMMON_SECTIONS)
 atmega1281: $(PROGRAM)_atmega1281_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega1281: $(PROGRAM)_atmega1281_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -302,7 +427,10 @@ atmega2561: TARGET = atmega2561
 atmega2561: MCU_TARGET = atmega2561
 atmega2561: CFLAGS += $(COMMON_OPTIONS) -DBIGBOOT $(UART_CMD)
 atmega2561: AVR_FREQ ?= 16000000L
-atmega2561: LDSECTIONS = -Wl,--section-start=.text=0x3fc00 -Wl,--section-start=.version=0x3fffe
+atmega2561: FLASH_SIZE_KIB = 256
+## bigboot version is 1024 Bytes long; starts earlier
+atmega2561: BOOT_SECTION_SIZE_KIB = 1
+atmega2561: LDSECTIONS = $(COMMON_SECTIONS)
 atmega2561: $(PROGRAM)_atmega2561_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega2561: $(PROGRAM)_atmega2561_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -313,7 +441,13 @@ atmega3290: TARGET = atmega3290
 atmega3290: MCU_TARGET = atmega3290
 atmega3290: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega3290: AVR_FREQ ?= 16000000L
-atmega3290: LDSECTIONS = -Wl,--section-start=.text=0x7e00 -Wl,--section-start=.version=0x7ffe
+atmega3290: FLASH_SIZE_KIB = 32
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega3290: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega3290: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega3290: LDSECTIONS = $(COMMON_SECTIONS)
 atmega3290: $(PROGRAM)_atmega3290_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega3290: $(PROGRAM)_atmega3290_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -324,7 +458,13 @@ atmega3290p: TARGET = atmega3290p
 atmega3290p: MCU_TARGET = atmega3290p
 atmega3290p: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega3290p: AVR_FREQ ?= 16000000L
-atmega3290p: LDSECTIONS = -Wl,--section-start=.text=0x7e00 -Wl,--section-start=.version=0x7ffe
+atmega3290p: FLASH_SIZE_KIB = 32
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega3290p: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega3290p: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega3290p: LDSECTIONS = $(COMMON_SECTIONS)
 atmega3290p: $(PROGRAM)_atmega3290p_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega3290p: $(PROGRAM)_atmega3290p_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -336,7 +476,13 @@ atmega6490: TARGET = atmega6490
 atmega6490: MCU_TARGET = atmega6490
 atmega6490: CFLAGS += $(COMMON_OPTIONS) -DBIGBOOT $(UART_CMD)
 atmega6490: AVR_FREQ ?= 16000000L
-atmega6490: LDSECTIONS = -Wl,--section-start=.text=0xfc00 -Wl,--section-start=.version=0xfffe
+atmega6490: FLASH_SIZE_KIB = 64
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega6490: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega6490: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega6490: LDSECTIONS = $(COMMON_SECTIONS)
 atmega6490: $(PROGRAM)_atmega6490_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega6490: $(PROGRAM)_atmega6490_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -347,7 +493,13 @@ atmega6490p: TARGET = atmega6490p
 atmega6490p: MCU_TARGET = atmega6490p
 atmega6490p: CFLAGS += $(COMMON_OPTIONS) -DBIGBOOT $(UART_CMD)
 atmega6490p: AVR_FREQ ?= 16000000L
-atmega6490p: LDSECTIONS = -Wl,--section-start=.text=0xfc00 -Wl,--section-start=.version=0xfffe
+atmega6490p: FLASH_SIZE_KIB = 64
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega6490p: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega6490p: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega6490p: LDSECTIONS = $(COMMON_SECTIONS)
 atmega6490p: $(PROGRAM)_atmega6490p_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega6490p: $(PROGRAM)_atmega6490p_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -358,7 +510,13 @@ atmega8515: TARGET = atmega8515
 atmega8515: MCU_TARGET = atmega8515
 atmega8515: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega8515: AVR_FREQ ?= 16000000L
-atmega8515: LDSECTIONS = -Wl,--section-start=.text=0x1e00 -Wl,--section-start=.version=0x1ffe
+atmega8515: FLASH_SIZE_KIB = 8
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega8515: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega8515: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega8515: LDSECTIONS = $(COMMON_SECTIONS)
 atmega8515: $(PROGRAM)_atmega8515_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega8515: $(PROGRAM)_atmega8515_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
@@ -369,7 +527,13 @@ atmega8535: TARGET := atmega8535
 atmega8535: MCU_TARGET = atmega8535
 atmega8535: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega8535: AVR_FREQ ?= 16000000L
-atmega8535: LDSECTIONS = -Wl,--section-start=.text=0x1e00 -Wl,--section-start=.version=0x1ffe
+atmega8535: FLASH_SIZE_KIB = 8
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+atmega8535: BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+atmega8535: BOOT_SECTION_SIZE_KIB = 1
+endif
+atmega8535: LDSECTIONS = $(COMMON_SECTIONS)
 atmega8535: $(PROGRAM)_atmega8535_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
 ifndef PRODUCTION
 atmega8535: $(PROGRAM)_atmega8535_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst

--- a/optiboot/bootloaders/optiboot/Makefile.mcudude
+++ b/optiboot/bootloaders/optiboot/Makefile.mcudude
@@ -42,6 +42,24 @@ atmega16: $(PROGRAM)_atmega16_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
 endif
 atmega16a: atmega16
 
+#ATmega32/A
+#atmega32: TARGET = atmega32
+#atmega32: MCU_TARGET = atmega32
+#atmega32: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
+#atmega32: AVR_FREQ ?= 16000000L
+#atmega32: FLASH_SIZE_KIB = 32
+#ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+#atmega32: BOOT_SECTION_SIZE_B = 512
+#else ## bigboot version is 1024 Bytes long; starts earlier
+#atmega32: BOOT_SECTION_SIZE_KIB = 1
+#endif
+#atmega32: LDSECTIONS = $(COMMON_SECTIONS)
+#atmega32: $(PROGRAM)_atmega32_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).hex
+#ifndef PRODUCTION
+#atmega32: $(PROGRAM)_atmega32_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ).lst
+#endif
+atmega32a: atmega32
+
 #ATmega64/A
 atmega64: TARGET = atmega64
 atmega64: MCU_TARGET = atmega64

--- a/optiboot/bootloaders/optiboot/Makefile.mega0
+++ b/optiboot/bootloaders/optiboot/Makefile.mega0
@@ -8,6 +8,9 @@
 # * This software is licensed under version 2 of the Gnu Public Licence.
 # * See optiboot.c for details.
 
+# include file that contains common definitions of variables
+include Makefile.inc
+
 HELPTEXT = "\n"
 #----------------------------------------------------------------------
 #
@@ -18,15 +21,16 @@ MF:= $(MAKEFILE_LIST)
 # defaults
 MCU_TARGET = atmega4809
 
-ifdef BIGBOOT
-LDSECTIONS  = -Wl,-section-start=.text=0 \
-	      -Wl,--section-start=.application=0x400 \
-	      -Wl,--section-start=.version=0x3fe
-else
-LDSECTIONS  = -Wl,-section-start=.text=0 \
-	      -Wl,--section-start=.application=0x200 \
-	      -Wl,--section-start=.version=0x1fe
+
+BOOTSECTION_FIRST = 1
+#FLASH_SIZE_KIB does not need to be defined if bootsection first
+ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
+BOOT_SECTION_SIZE_B = 512
+else ## bigboot version is 1024 Bytes long; starts earlier
+BOOT_SECTION_SIZE_KIB = 1
 endif
+LDSECTIONS = $(COMMON_SECTIONS)
+
 
 BAUD_RATE=115200
 

--- a/optiboot/bootloaders/optiboot/Makefile.tiny
+++ b/optiboot/bootloaders/optiboot/Makefile.tiny
@@ -369,21 +369,21 @@ endif
 #-----------------------
 
 attiny841at20noLED:
-	$(MAKE) attiny841	 AVR_FREQ=20000000L LED_START_FLASHES=0  LDSECTIONS  = -Wl,--section-start=.text=0x1dc0 -Wl,--section-start=.version=0x1ffe
+	$(MAKE) attiny841	 AVR_FREQ=20000000L LED_START_FLASHES=0  LDSECTIONS= -Wl,--section-start=.text=0x1dc0 -Wl,--section-start=.version=0x1ffe
 	mv $(PROGRAM)_attiny841.hex $(PROGRAM)_attiny841_20000000L_noLED.hex
 ifndef PRODUCTION
 	mv $(PROGRAM)_attiny841.lst $(PROGRAM)_attiny841_20000000L_noLED.lst
 endif
 
 attiny841at16noLED:
-	$(MAKE) attiny841	 AVR_FREQ=16000000L LED_START_FLASHES=0 LDSECTIONS  = -Wl,--section-start=.text=0x1dc0 -Wl,--section-start=.version=0x1ffe
+	$(MAKE) attiny841	 AVR_FREQ=16000000L LED_START_FLASHES=0 LDSECTIONS= -Wl,--section-start=.text=0x1dc0 -Wl,--section-start=.version=0x1ffe
 	mv $(PROGRAM)_attiny841.hex $(PROGRAM)_attiny841_16000000L_noLED.hex
 ifndef PRODUCTION
 	mv $(PROGRAM)_attiny841.lst $(PROGRAM)_attiny841_16000000L_noLED.lst
 endif
 
 attiny841at8noLED:
-	$(MAKE) attiny841	 AVR_FREQ=8000000L  BAUD_RATE=57600 LED_START_FLASHES=0 LDSECTIONS  = -Wl,--section-start=.text=0x1dc0 -Wl,--section-start=.version=0x1ffe
+	$(MAKE) attiny841	 AVR_FREQ=8000000L  BAUD_RATE=57600 LED_START_FLASHES=0 LDSECTIONS= -Wl,--section-start=.text=0x1dc0 -Wl,--section-start=.version=0x1ffe
 	mv $(PROGRAM)_attiny841.hex $(PROGRAM)_attiny841_8000000L_noLED.hex
 ifndef PRODUCTION
 	mv $(PROGRAM)_attiny841.lst $(PROGRAM)_attiny841_8000000L_noLED.lst
@@ -595,21 +595,21 @@ endif
 #-----------------------
 
 attiny441at20noLED:
-	$(MAKE) attiny441	 AVR_FREQ=20000000L LED_START_FLASHES=0  LDSECTIONS  = -Wl,--section-start=.text=0x0dc0 -Wl,--section-start=.version=0x0ffe
+	$(MAKE) attiny441	 AVR_FREQ=20000000L LED_START_FLASHES=0  LDSECTIONS= -Wl,--section-start=.text=0x0dc0 -Wl,--section-start=.version=0x0ffe
 	mv $(PROGRAM)_attiny441.hex $(PROGRAM)_attiny441_20000000L_noLED.hex
 ifndef PRODUCTION
 	mv $(PROGRAM)_attiny441.lst $(PROGRAM)_attiny441_20000000L_noLED.lst
 endif
 
 attiny441at16noLED:
-	$(MAKE) attiny441	 AVR_FREQ=16000000L LED_START_FLASHES=0 LDSECTIONS  = -Wl,--section-start=.text=0x0dc0 -Wl,--section-start=.version=0x0ffe
+	$(MAKE) attiny441	 AVR_FREQ=16000000L LED_START_FLASHES=0 LDSECTIONS= -Wl,--section-start=.text=0x0dc0 -Wl,--section-start=.version=0x0ffe
 	mv $(PROGRAM)_attiny441.hex $(PROGRAM)_attiny441_16000000L_noLED.hex
 ifndef PRODUCTION
 	mv $(PROGRAM)_attiny441.lst $(PROGRAM)_attiny441_16000000L_noLED.lst
 endif
 
 attiny441at8noLED:
-	$(MAKE) attiny441	 AVR_FREQ=8000000L  BAUD_RATE=57600 LED_START_FLASHES=0 LDSECTIONS  = -Wl,--section-start=.text=0x0dc0 -Wl,--section-start=.version=0x0ffe
+	$(MAKE) attiny441	 AVR_FREQ=8000000L  BAUD_RATE=57600 LED_START_FLASHES=0 LDSECTIONS= -Wl,--section-start=.text=0x0dc0 -Wl,--section-start=.version=0x0ffe
 	mv $(PROGRAM)_attiny441.hex $(PROGRAM)_attiny441_8000000L_noLED.hex
 ifndef PRODUCTION
 	mv $(PROGRAM)_attiny441.lst $(PROGRAM)_attiny441_8000000L_noLED.lst

--- a/optiboot/bootloaders/optiboot/Makefile.tiny
+++ b/optiboot/bootloaders/optiboot/Makefile.tiny
@@ -368,22 +368,28 @@ endif
 # on the 1634 means that you don't gain any usable flash from it.
 #-----------------------
 
+# Start address of 1DC0 allows for size up to 576 bytes, app up to 7616
+attiny841at20noLED: LDSECTIONS = $(COMMON_SECTIONS)
 attiny841at20noLED:
-	$(MAKE) attiny841	 AVR_FREQ=20000000L LED_START_FLASHES=0  LDSECTIONS= -Wl,--section-start=.text=0x1dc0 -Wl,--section-start=.version=0x1ffe
+	$(MAKE) attiny841	 AVR_FREQ=20000000L LED_START_FLASHES=0 BOOT_SECTION_SIZE_B=576
 	mv $(PROGRAM)_attiny841.hex $(PROGRAM)_attiny841_20000000L_noLED.hex
 ifndef PRODUCTION
 	mv $(PROGRAM)_attiny841.lst $(PROGRAM)_attiny841_20000000L_noLED.lst
 endif
 
+# Start address of 1DC0 allows for size up to 576 bytes, app up to 7616
+attiny841at16noLED: LDSECTIONS = $(COMMON_SECTIONS)
 attiny841at16noLED:
-	$(MAKE) attiny841	 AVR_FREQ=16000000L LED_START_FLASHES=0 LDSECTIONS= -Wl,--section-start=.text=0x1dc0 -Wl,--section-start=.version=0x1ffe
+	$(MAKE) attiny841	 AVR_FREQ=16000000L LED_START_FLASHES=0 BOOT_SECTION_SIZE_B=576
 	mv $(PROGRAM)_attiny841.hex $(PROGRAM)_attiny841_16000000L_noLED.hex
 ifndef PRODUCTION
 	mv $(PROGRAM)_attiny841.lst $(PROGRAM)_attiny841_16000000L_noLED.lst
 endif
 
+# Start address of 1DC0 allows for size up to 576 bytes, app up to 7616
+attiny841at8noLED: LDSECTIONS = $(COMMON_SECTIONS)
 attiny841at8noLED:
-	$(MAKE) attiny841	 AVR_FREQ=8000000L  BAUD_RATE=57600 LED_START_FLASHES=0 LDSECTIONS= -Wl,--section-start=.text=0x1dc0 -Wl,--section-start=.version=0x1ffe
+	$(MAKE) attiny841	 AVR_FREQ=8000000L  BAUD_RATE=57600 LED_START_FLASHES=0 BOOT_SECTION_SIZE_B=576
 	mv $(PROGRAM)_attiny841.hex $(PROGRAM)_attiny841_8000000L_noLED.hex
 ifndef PRODUCTION
 	mv $(PROGRAM)_attiny841.lst $(PROGRAM)_attiny841_8000000L_noLED.lst
@@ -594,22 +600,28 @@ endif
 # on the 1634 means that you don't gain any usable flash from it.
 #-----------------------
 
+# Start address of 0DC0 allows for size up to 576 bytes, app up to 3520
+attiny441at20noLED: LDSECTIONS = $(COMMON_SECTIONS)
 attiny441at20noLED:
-	$(MAKE) attiny441	 AVR_FREQ=20000000L LED_START_FLASHES=0  LDSECTIONS= -Wl,--section-start=.text=0x0dc0 -Wl,--section-start=.version=0x0ffe
+	$(MAKE) attiny441	 AVR_FREQ=20000000L LED_START_FLASHES=0 BOOT_SECTION_SIZE_B=576
 	mv $(PROGRAM)_attiny441.hex $(PROGRAM)_attiny441_20000000L_noLED.hex
 ifndef PRODUCTION
 	mv $(PROGRAM)_attiny441.lst $(PROGRAM)_attiny441_20000000L_noLED.lst
 endif
 
+# Start address of 0DC0 allows for size up to 576 bytes, app up to 3520
+attiny441at16noLED: LDSECTIONS = $(COMMON_SECTIONS)
 attiny441at16noLED:
-	$(MAKE) attiny441	 AVR_FREQ=16000000L LED_START_FLASHES=0 LDSECTIONS= -Wl,--section-start=.text=0x0dc0 -Wl,--section-start=.version=0x0ffe
+	$(MAKE) attiny441	 AVR_FREQ=16000000L LED_START_FLASHES=0 BOOT_SECTION_SIZE_B=576
 	mv $(PROGRAM)_attiny441.hex $(PROGRAM)_attiny441_16000000L_noLED.hex
 ifndef PRODUCTION
 	mv $(PROGRAM)_attiny441.lst $(PROGRAM)_attiny441_16000000L_noLED.lst
 endif
 
+# Start address of 0DC0 allows for size up to 576 bytes, app up to 3520
+attiny441at8noLED: LDSECTIONS = $(COMMON_SECTIONS)
 attiny441at8noLED:
-	$(MAKE) attiny441	 AVR_FREQ=8000000L  BAUD_RATE=57600 LED_START_FLASHES=0 LDSECTIONS= -Wl,--section-start=.text=0x0dc0 -Wl,--section-start=.version=0x0ffe
+	$(MAKE) attiny441	 AVR_FREQ=8000000L  BAUD_RATE=57600 LED_START_FLASHES=0 BOOT_SECTION_SIZE_B=576
 	mv $(PROGRAM)_attiny441.hex $(PROGRAM)_attiny441_8000000L_noLED.hex
 ifndef PRODUCTION
 	mv $(PROGRAM)_attiny441.lst $(PROGRAM)_attiny441_8000000L_noLED.lst
@@ -1377,7 +1389,6 @@ attiny167: TARGET = attiny167
 attiny167: MCU_TARGET = attiny167
 attiny167: AVR_FREQ ?= 8000000L
 attiny167: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION'
-#attiny167: LDSECTIONS  = -Wl,--section-start=.text=0x1d80 -Wl,--section-start=.version=0x1ffe
 attiny167: FLASH_SIZE_KIB = 16
 # Start address of 1D80 allows for size up to 640 bytes, app up to 7552
 attiny167: BOOT_SECTION_SIZE_B = 640
@@ -1392,7 +1403,6 @@ attiny87: TARGET = attiny87
 attiny87: MCU_TARGET = attiny87
 attiny87: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION'
 attiny87: AVR_FREQ ?= 8000000L
-#attiny87: LDSECTIONS  = -Wl,--section-start=.text=0x1d80 -Wl,--section-start=.version=0x1ffe
 attiny87: FLASH_SIZE_KIB = 8
 # Start address of 1D80 allows for size up to 640 bytes, app up to 7552
 attiny87: BOOT_SECTION_SIZE_B = 640

--- a/optiboot/bootloaders/optiboot/Makefile.tiny
+++ b/optiboot/bootloaders/optiboot/Makefile.tiny
@@ -10,7 +10,10 @@ attiny1634:	MCU_TARGET = attiny1634
 attiny1634:	LED_CMD ?= -DLED=C0
 attiny1634: CFLAGS += $(COMMON_OPTIONS) -DVIRTUAL_BOOT_PARTITION -DFOURPAGEERASE $(UART_CMD)
 attiny1634: AVR_FREQ ?= 8000000L
-attiny1634: LDSECTIONS  = -Wl,--section-start=.text=0x3d80 -Wl,--section-start=.version=0x3ffe
+attiny1634: FLASH_SIZE_KIB = 16
+# Start address of 3D80 allows for size up to 640 bytes, app up to 15744
+attiny1634: BOOT_SECTION_SIZE_B = 640
+attiny1634: LDSECTIONS = $(COMMON_SECTIONS)
 attiny1634: $(PROGRAM)_attiny1634.hex
 ifndef PRODUCTION
 attiny1634: $(PROGRAM)_attiny1634.lst
@@ -178,7 +181,10 @@ attiny841: TARGET = attiny841
 attiny841: MCU_TARGET = attiny841
 attiny841: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION' '-DFOURPAGEERASE' $(UART_CMD)
 attiny841: AVR_FREQ ?= 8000000L
-attiny841: LDSECTIONS  = -Wl,--section-start=.text=0x1d80 -Wl,--section-start=.version=0x1ffe
+attiny841: FLASH_SIZE_KIB = 8
+# Start address of 1D80 allows for size up to 640 bytes, app up to 7552
+attiny841: BOOT_SECTION_SIZE_B = 640
+attiny841: LDSECTIONS = $(COMMON_SECTIONS)
 attiny841: $(PROGRAM)_attiny841.hex
 ifndef PRODUCTION
 attiny841: $(PROGRAM)_attiny841.lst
@@ -395,7 +401,10 @@ attiny441: TARGET = attiny441
 attiny441: MCU_TARGET = attiny441
 attiny441: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION' '-DFOURPAGEERASE' $(UART_CMD)
 attiny441: AVR_FREQ ?= 8000000L
-attiny441: LDSECTIONS  = -Wl,--section-start=.text=0x0d80 -Wl,--section-start=.version=0x0ffe
+attiny441: FLASH_SIZE_KIB = 4
+# Start address of 0D80 allows for size up to 640 bytes, app up to 3456
+attiny441: BOOT_SECTION_SIZE_B = 640
+attiny441: LDSECTIONS = $(COMMON_SECTIONS)
 attiny441: $(PROGRAM)_attiny441.hex
 ifndef PRODUCTION
 attiny441: $(PROGRAM)_attiny441.lst
@@ -617,7 +626,10 @@ attiny828: TARGET = attiny828
 attiny828: MCU_TARGET = attiny828
 attiny828: CFLAGS += $(COMMON_OPTIONS)
 attiny828: AVR_FREQ ?= 8000000L
-attiny828: LDSECTIONS  = -Wl,--section-start=.text=0x1E00 -Wl,--section-start=.version=0x1ffe
+attiny828: FLASH_SIZE_KIB = 8
+# Start address of 1E00 allows for size up to 640 bytes, app up to 7552
+attiny828: BOOT_SECTION_SIZE_B = 640
+attiny828: LDSECTIONS = $(COMMON_SECTIONS)
 attiny828: $(PROGRAM)_attiny828.hex
 ifndef PRODUCTION
 attiny828: $(PROGRAM)_attiny828.lst
@@ -683,7 +695,10 @@ attiny88: TARGET = attiny88
 attiny88: MCU_TARGET = attiny88
 attiny88: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION' '-DSOFT_UART'
 attiny88: AVR_FREQ ?= 8000000L
-attiny88: LDSECTIONS  = -Wl,--section-start=.text=0x1D80 -Wl,--section-start=.version=0x1ffe
+attiny88: FLASH_SIZE_KIB = 8
+# Start address of 1D80 allows for size up to 640 bytes, app up to 7552
+attiny88: BOOT_SECTION_SIZE_B = 640
+attiny88: LDSECTIONS = $(COMMON_SECTIONS)
 attiny88: $(PROGRAM)_attiny88.hex
 ifndef PRODUCTION
 attiny88: $(PROGRAM)_attiny88.lst
@@ -750,7 +765,10 @@ attiny48: TARGET = attiny48
 attiny48: MCU_TARGET = attiny48
 attiny48: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION' '-DSOFT_UART'
 attiny48: AVR_FREQ ?= 8000000L
-attiny48: LDSECTIONS  = -Wl,--section-start=.text=0x0D80 -Wl,--section-start=.version=0x1ffe
+attiny48: FLASH_SIZE_KIB = 4
+# Start address of 0D80 allows for size up to 640 bytes, app up to 3456
+attiny48: BOOT_SECTION_SIZE_B = 640
+attiny48: LDSECTIONS = $(COMMON_SECTIONS)
 attiny48: $(PROGRAM)_attiny48.hex
 ifndef PRODUCTION
 attiny48: $(PROGRAM)_attiny48.lst
@@ -817,7 +835,10 @@ attiny85: MCU_TARGET = attiny85
 attiny85: LED_START_FLASHES_CMD = '-DLED_START_FLASHES=0'
 attiny85: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION' '-DSOFT_UART'
 attiny85: AVR_FREQ ?= 8000000L
-attiny85: LDSECTIONS  = -Wl,--section-start=.text=0x1DC0 -Wl,--section-start=.version=0x1ffe
+attiny88: FLASH_SIZE_KIB = 8
+# Start address of 1DC0 allows for size up to 576 bytes, app up to 7616
+attiny88: BOOT_SECTION_SIZE_B = 576
+attiny88: LDSECTIONS = $(COMMON_SECTIONS)
 attiny85: $(PROGRAM)_attiny85.hex
 ifndef PRODUCTION
 attiny85: $(PROGRAM)_attiny85.lst
@@ -904,7 +925,10 @@ attiny45: MCU_TARGET = attiny45
 attiny45: LED_START_FLASHES_CMD = '-DLED_START_FLASHES=0'
 attiny45: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION' '-DSOFT_UART'
 attiny45: AVR_FREQ ?= 8000000L
-attiny45: LDSECTIONS  = -Wl,--section-start=.text=0x0DC0 -Wl,--section-start=.version=0x0ffe
+attiny45: FLASH_SIZE_KIB = 4
+# Start address of 0DC0 allows for size up to 576 bytes, app up to 3520
+attiny45: BOOT_SECTION_SIZE_B = 640
+attiny45: LDSECTIONS = $(COMMON_SECTIONS)
 attiny45: $(PROGRAM)_attiny45.hex
 ifndef PRODUCTION
 attiny45: $(PROGRAM)_attiny45.lst
@@ -991,7 +1015,10 @@ attiny84: TARGET = attiny84
 attiny84: MCU_TARGET = attiny84
 attiny84: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION' '-DSOFT_UART'
 attiny84: AVR_FREQ ?= 8000000L
-attiny84: LDSECTIONS  = -Wl,--section-start=.text=0x1D80 -Wl,--section-start=.version=0x1ffe
+attiny84: FLASH_SIZE_KIB = 8
+# Start address of 1D80 allows for size up to 640 bytes, app up to 7552
+attiny84: BOOT_SECTION_SIZE_B = 640
+attiny84: LDSECTIONS = $(COMMON_SECTIONS)
 attiny84: $(PROGRAM)_attiny84.hex
 ifndef PRODUCTION
 attiny84: $(PROGRAM)_attiny84.lst
@@ -1078,7 +1105,10 @@ attiny44: TARGET = attiny44
 attiny44: MCU_TARGET = attiny44
 attiny44: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION' '-DSOFT_UART'
 attiny44: AVR_FREQ ?= 8000000L
-attiny44: LDSECTIONS  = -Wl,--section-start=.text=0x0D80 -Wl,--section-start=.version=0x0ffe
+attiny44: FLASH_SIZE_KIB = 4
+# Start address of 0D80 allows for size up to 640 bytes, app up to 3456
+attiny44: BOOT_SECTION_SIZE_B = 640
+attiny44: LDSECTIONS = $(COMMON_SECTIONS)
 attiny44: $(PROGRAM)_attiny44.hex
 ifndef PRODUCTION
 attiny44: $(PROGRAM)_attiny44.lst
@@ -1166,7 +1196,10 @@ attiny861: TARGET = attiny861
 attiny861: MCU_TARGET = attiny861
 attiny861: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION' '-DSOFT_UART'
 attiny861: AVR_FREQ ?= 8000000L
-attiny861: LDSECTIONS  = -Wl,--section-start=.text=0x1D80 -Wl,--section-start=.version=0x1ffe
+attiny861: FLASH_SIZE_KIB = 8
+# Start address of 1D80 allows for size up to 640 bytes, app up to 7552
+attiny861: BOOT_SECTION_SIZE_B = 640
+attiny861: LDSECTIONS = $(COMMON_SECTIONS)
 attiny861: $(PROGRAM)_attiny861.hex
 ifndef PRODUCTION
 attiny861: $(PROGRAM)_attiny861.lst
@@ -1253,7 +1286,10 @@ attiny461: TARGET = attiny461
 attiny461: MCU_TARGET = attiny461
 attiny461: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION' '-DSOFT_UART'
 attiny461: AVR_FREQ ?= 8000000L
-attiny461: LDSECTIONS  = -Wl,--section-start=.text=0x0D80 -Wl,--section-start=.version=0x0ffe
+attiny461: FLASH_SIZE_KIB = 4
+# Start address of 0D80 allows for size up to 640 bytes, app up to 3456
+attiny461: BOOT_SECTION_SIZE_B = 640
+attiny461: LDSECTIONS = $(COMMON_SECTIONS)
 attiny461: $(PROGRAM)_attiny461.hex
 ifndef PRODUCTION
 attiny461: $(PROGRAM)_attiny461.lst
@@ -1341,7 +1377,11 @@ attiny167: TARGET = attiny167
 attiny167: MCU_TARGET = attiny167
 attiny167: AVR_FREQ ?= 8000000L
 attiny167: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION'
-attiny167: LDSECTIONS  = -Wl,--section-start=.text=0x1d80 -Wl,--section-start=.version=0x1ffe
+#attiny167: LDSECTIONS  = -Wl,--section-start=.text=0x1d80 -Wl,--section-start=.version=0x1ffe
+attiny167: FLASH_SIZE_KIB = 16
+# Start address of 1D80 allows for size up to 640 bytes, app up to 7552
+attiny167: BOOT_SECTION_SIZE_B = 640
+attiny167: LDSECTIONS = $(COMMON_SECTIONS)
 attiny167: $(PROGRAM)_attiny167.hex
 ifndef PRODUCTION
 attiny167: $(PROGRAM)_attiny167.lst
@@ -1352,7 +1392,11 @@ attiny87: TARGET = attiny87
 attiny87: MCU_TARGET = attiny87
 attiny87: CFLAGS += $(COMMON_OPTIONS) '-DVIRTUAL_BOOT_PARTITION'
 attiny87: AVR_FREQ ?= 8000000L
-attiny87: LDSECTIONS  = -Wl,--section-start=.text=0x1d80 -Wl,--section-start=.version=0x1ffe
+#attiny87: LDSECTIONS  = -Wl,--section-start=.text=0x1d80 -Wl,--section-start=.version=0x1ffe
+attiny87: FLASH_SIZE_KIB = 8
+# Start address of 1D80 allows for size up to 640 bytes, app up to 7552
+attiny87: BOOT_SECTION_SIZE_B = 640
+attiny87: LDSECTIONS = $(COMMON_SECTIONS)
 attiny87: $(PROGRAM)_attiny87.hex
 ifndef PRODUCTION
 attiny87: $(PROGRAM)_attiny87.lst

--- a/optiboot/bootloaders/optiboot/Makefile.usbmcus
+++ b/optiboot/bootloaders/optiboot/Makefile.usbmcus
@@ -32,7 +32,7 @@ atmega8u2atUART: BOOT_SECTION_SIZE_B = 512
 else ## bigboot version is 1024 Bytes long; starts earlier
 atmega8u2atUART: BOOT_SECTION_SIZE_KIB = 1
 endif
-atmega8u2atUART: LDSECTIONS = $(COMMON_SECTIONS) -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
+atmega8u2atUART: LDSECTIONS = $(COMMON_SECTIONS) $(COMMON_SECTIONS)
 atmega8u2atUART: $(PROGRAM)_atmega8u2_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 atmega8u2atUART: $(PROGRAM)_atmega8u2_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst
@@ -68,7 +68,7 @@ atmega16u2atUART: BOOT_SECTION_SIZE_B = 512
 else ## bigboot version is 1024 Bytes long; starts earlier
 atmega16u2atUART: BOOT_SECTION_SIZE_KIB = 1
 endif
-atmega16u2atUART: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
+atmega16u2atUART: LDSECTIONS = $(COMMON_SECTIONS)
 atmega16u2atUART: $(PROGRAM)_atmega16u2_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 atmega16u2atUART: $(PROGRAM)_atmega16u2_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst
@@ -104,7 +104,7 @@ atmega32u2atUART: BOOT_SECTION_SIZE_B = 512
 else ## bigboot version is 1024 Bytes long; starts earlier
 atmega32u2atUART: BOOT_SECTION_SIZE_KIB = 1
 endif
-atmega32u2atUART: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
+atmega32u2atUART: LDSECTIONS = $(COMMON_SECTIONS)
 atmega32u2atUART: $(PROGRAM)_atmega32u2_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 atmega32u2atUART: $(PROGRAM)_atmega32u2_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst
@@ -140,7 +140,7 @@ atmega16u4atUART: BOOT_SECTION_SIZE_B = 512
 else ## bigboot version is 1024 Bytes long; starts earlier
 atmega16u4atUART: BOOT_SECTION_SIZE_KIB = 1
 endif
-atmega16u4atUART: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
+atmega16u4atUART: LDSECTIONS = $(COMMON_SECTIONS)
 atmega16u4atUART: $(PROGRAM)_atmega16u4_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 atmega16u4atUART: $(PROGRAM)_atmega16u4_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst
@@ -177,7 +177,7 @@ atmega32u4atUART: BOOT_SECTION_SIZE_B = 512
 else ## bigboot version is 1024 Bytes long; starts earlier
 atmega32u4atUART: BOOT_SECTION_SIZE_KIB = 1
 endif
-atmega32u4atUART: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
+atmega32u4atUART: LDSECTIONS = $(COMMON_SECTIONS)
 atmega32u4atUART: $(PROGRAM)_atmega32u4_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 atmega32u4atUART: $(PROGRAM)_atmega32u4_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst
@@ -216,7 +216,7 @@ atmega32u6atUART: BOOT_SECTION_SIZE_B = 512
 else ## bigboot version is 1024 Bytes long; starts earlier
 atmega32u6atUART: BOOT_SECTION_SIZE_KIB = 1
 endif
-atmega32u6atUART: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
+atmega32u6atUART: LDSECTIONS = $(COMMON_SECTIONS)
 atmega32u6atUART: $(PROGRAM)_atmega32u6_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 atmega32u6atUART: $(PROGRAM)_atmega32u6_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst
@@ -252,7 +252,7 @@ at90usb646atUART: BOOT_SECTION_SIZE_KIB = 1
 else ## bigboot version is 2048 Bytes long; starts earlier
 at90usb646atUART: BOOT_SECTION_SIZE_KIB = 2
 endif
-at90usb646atUART: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
+at90usb646atUART: LDSECTIONS = $(COMMON_SECTIONS)
 at90usb646atUART: $(PROGRAM)_at90usb646_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 at90usb646atUART: $(PROGRAM)_at90usb646_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst
@@ -288,7 +288,7 @@ at90usb647atUART: BOOT_SECTION_SIZE_KIB = 1
 else ## bigboot version is 2048 Bytes long; starts earlier
 at90usb647atUART: BOOT_SECTION_SIZE_KIB = 2
 endif
-at90usb647atUART: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
+at90usb647atUART: LDSECTIONS = $(COMMON_SECTIONS)
 at90usb647atUART: $(PROGRAM)_at90usb647_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 at90usb647atUART: $(PROGRAM)_at90usb647_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst
@@ -324,7 +324,7 @@ at90usb1286atUART: BOOT_SECTION_SIZE_KIB = 1
 else ## bigboot version is 2048 Bytes long; starts earlier
 at90usb1286atUART: BOOT_SECTION_SIZE_KIB = 2
 endif
-at90usb1286atUART: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
+at90usb1286atUART: LDSECTIONS = $(COMMON_SECTIONS)
 at90usb1286atUART: $(PROGRAM)_at90usb1286_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 at90usb1286atUART: $(PROGRAM)_at90usb1286_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst
@@ -360,7 +360,7 @@ at90usb1287atUART: BOOT_SECTION_SIZE_KIB = 1
 else ## bigboot version is 2048 Bytes long; starts earlier
 at90usb1287atUART: BOOT_SECTION_SIZE_KIB = 2
 endif
-at90usb1287atUART: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
+at90usb1287atUART: LDSECTIONS = $(COMMON_SECTIONS)
 at90usb1287atUART: $(PROGRAM)_at90usb1287_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 at90usb1287atUART: $(PROGRAM)_at90usb1287_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst

--- a/optiboot/bootloaders/optiboot/Makefile.usbmcus
+++ b/optiboot/bootloaders/optiboot/Makefile.usbmcus
@@ -14,7 +14,10 @@
 
 HELPTEXT += "target atmega8/16/32u2, atmega16/32u4 - newer 32/44pin AVR-USB-MCUs \n"
 
+# include file that contains common definitions of variables
+include Makefile.inc
 
+COMMON_SECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET)
 #-----------------------
 # ATmega 8u2
 #-----------------------
@@ -23,11 +26,13 @@ atmega8u2atUART: TARGET = atmega8u2
 atmega8u2atUART: MCU_TARGET = atmega8u2
 atmega8u2atUART: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega8u2atUART: AVR_FREQ ?= 16000000L
+atmega8u2atUART: FLASH_SIZE_KIB = 8
 ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
-atmega8u2atUART: LDSECTIONS = -Wl,--section-start=.text=0x1e00 -Wl,--section-start=.version=0x1ffe
+atmega8u2atUART: BOOT_SECTION_SIZE_B = 512
 else ## bigboot version is 1024 Bytes long; starts earlier
-atmega8u2atUART: LDSECTIONS = -Wl,--section-start=.text=0x1c00 -Wl,--section-start=.version=0x1ffe
+atmega8u2atUART: BOOT_SECTION_SIZE_KIB = 1
 endif
+atmega8u2atUART: LDSECTIONS = $(COMMON_SECTIONS) -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
 atmega8u2atUART: $(PROGRAM)_atmega8u2_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 atmega8u2atUART: $(PROGRAM)_atmega8u2_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst
@@ -57,11 +62,13 @@ atmega16u2atUART: TARGET = atmega16u2
 atmega16u2atUART: MCU_TARGET = atmega16u2
 atmega16u2atUART: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega16u2atUART: AVR_FREQ ?= 16000000L
+atmega16u2atUART: FLASH_SIZE_KIB = 16
 ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
-atmega16u2atUART: LDSECTIONS = -Wl,--section-start=.text=0x3e00 -Wl,--section-start=.version=0x3ffe
+atmega16u2atUART: BOOT_SECTION_SIZE_B = 512
 else ## bigboot version is 1024 Bytes long; starts earlier
-atmega16u2atUART: LDSECTIONS = -Wl,--section-start=.text=0x3c00 -Wl,--section-start=.version=0x3ffe
+atmega16u2atUART: BOOT_SECTION_SIZE_KIB = 1
 endif
+atmega16u2atUART: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
 atmega16u2atUART: $(PROGRAM)_atmega16u2_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 atmega16u2atUART: $(PROGRAM)_atmega16u2_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst
@@ -91,11 +98,13 @@ atmega32u2atUART: TARGET = atmega32u2
 atmega32u2atUART: MCU_TARGET = atmega32u2
 atmega32u2atUART: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega32u2atUART: AVR_FREQ ?= 16000000L
+atmega32u2atUART: FLASH_SIZE_KIB = 32
 ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
-atmega32u2atUART: LDSECTIONS = -Wl,--section-start=.text=0x7e00 -Wl,--section-start=.version=0x7ffe
+atmega32u2atUART: BOOT_SECTION_SIZE_B = 512
 else ## bigboot version is 1024 Bytes long; starts earlier
-atmega32u2atUART: LDSECTIONS = -Wl,--section-start=.text=0x7c00 -Wl,--section-start=.version=0x7ffe
+atmega32u2atUART: BOOT_SECTION_SIZE_KIB = 1
 endif
+atmega32u2atUART: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
 atmega32u2atUART: $(PROGRAM)_atmega32u2_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 atmega32u2atUART: $(PROGRAM)_atmega32u2_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst
@@ -125,11 +134,13 @@ atmega16u4atUART: TARGET = atmega16u4
 atmega16u4atUART: MCU_TARGET = atmega16u4
 atmega16u4atUART: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega16u4atUART: AVR_FREQ ?= 16000000L
+atmega16u4atUART: FLASH_SIZE_KIB = 16
 ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
-atmega16u4atUART: LDSECTIONS = -Wl,--section-start=.text=0x3e00 -Wl,--section-start=.version=0x3ffe
+atmega16u4atUART: BOOT_SECTION_SIZE_B = 512
 else ## bigboot version is 1024 Bytes long; starts earlier
-atmega16u4atUART: LDSECTIONS = -Wl,--section-start=.text=0x3c00 -Wl,--section-start=.version=0x3ffe
+atmega16u4atUART: BOOT_SECTION_SIZE_KIB = 1
 endif
+atmega16u4atUART: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
 atmega16u4atUART: $(PROGRAM)_atmega16u4_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 atmega16u4atUART: $(PROGRAM)_atmega16u4_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst
@@ -151,7 +162,6 @@ atmega16u4_isp: EFUSE ?= FB# = 2.6V brownout
 atmega16u4_isp: LOCK  ?= 2F# = APP protect mode 1, BL protect mode 2
 atmega16u4_isp: isp
 
-
 #-----------------------
 # ATmega 32u4
 #-----------------------
@@ -160,11 +170,14 @@ atmega32u4atUART: TARGET = atmega32u4
 atmega32u4atUART: MCU_TARGET = atmega32u4
 atmega32u4atUART: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega32u4atUART: AVR_FREQ ?= 16000000L
+atmega32u4atUART: FLASH_SIZE_KIB = 32
+atmega32u4atUART: BOOT_SECTION_SIZE_B = 512
 ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
-atmega32u4atUART: LDSECTIONS = -Wl,--section-start=.text=0x7e00 -Wl,--section-start=.version=0x7ffe
+atmega32u4atUART: BOOT_SECTION_SIZE_B = 512
 else ## bigboot version is 1024 Bytes long; starts earlier
-atmega32u4atUART: LDSECTIONS = -Wl,--section-start=.text=0x7c00 -Wl,--section-start=.version=0x7ffe
+atmega32u4atUART: BOOT_SECTION_SIZE_KIB = 1
 endif
+atmega32u4atUART: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
 atmega32u4atUART: $(PROGRAM)_atmega32u4_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 atmega32u4atUART: $(PROGRAM)_atmega32u4_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst
@@ -187,6 +200,8 @@ atmega32u4_isp: LOCK  ?= 2F# = APP protect mode 1, BL protect mode 2
 atmega32u4_isp: isp
 
 
+#VERSION = $(call CALC_ADDRESS_IN_HEX, ($(FLASH_SIZE_KB) * 1024) - ($(strip $(1))) )
+
 #-----------------------
 # ATmega 32u6
 #-----------------------
@@ -195,11 +210,13 @@ atmega32u6atUART: TARGET = atmega32u6
 atmega32u6atUART: MCU_TARGET = atmega32u6
 atmega32u6atUART: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega32u6atUART: AVR_FREQ ?= 16000000L
+atmega32u6atUART: FLASH_SIZE_KIB = 32
 ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
-atmega32u6atUART: LDSECTIONS = -Wl,--section-start=.text=0x7e00 -Wl,--section-start=.version=0x7ffe
+atmega32u6atUART: BOOT_SECTION_SIZE_B = 512
 else ## bigboot version is 1024 Bytes long; starts earlier
-atmega32u6atUART: LDSECTIONS = -Wl,--section-start=.text=0x7c00 -Wl,--section-start=.version=0x7ffe
+atmega32u6atUART: BOOT_SECTION_SIZE_KIB = 1
 endif
+atmega32u6atUART: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
 atmega32u6atUART: $(PROGRAM)_atmega32u6_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 atmega32u6atUART: $(PROGRAM)_atmega32u6_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst
@@ -229,11 +246,13 @@ at90usb646atUART: TARGET = at90usb646
 at90usb646atUART: MCU_TARGET = at90usb646
 at90usb646atUART: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 at90usb646atUART: AVR_FREQ ?= 16000000L
-ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
-at90usb646atUART: LDSECTIONS = -Wl,--section-start=.text=0xfc00 -Wl,--section-start=.version=0xfffe
-else ## bigboot version is 1024 Bytes long; starts earlier
-at90usb646atUART: LDSECTIONS = -Wl,--section-start=.text=0xf800 -Wl,--section-start=.version=0xfffe
+at90usb646atUART: FLASH_SIZE_KIB = 64
+ifndef BIGBOOT ## standard version is 1024 Bytes long; starts earlier
+at90usb646atUART: BOOT_SECTION_SIZE_KIB = 1
+else ## bigboot version is 2048 Bytes long; starts earlier
+at90usb646atUART: BOOT_SECTION_SIZE_KIB = 2
 endif
+at90usb646atUART: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
 at90usb646atUART: $(PROGRAM)_at90usb646_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 at90usb646atUART: $(PROGRAM)_at90usb646_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst
@@ -263,11 +282,13 @@ at90usb647atUART: TARGET = at90usb647
 at90usb647atUART: MCU_TARGET = at90usb647
 at90usb647atUART: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 at90usb647atUART: AVR_FREQ ?= 16000000L
+at90usb647atUART: FLASH_SIZE_KIB = 64
 ifndef BIGBOOT ## standard version is 1024 Bytes long; starts earlier
-at90usb647atUART: LDSECTIONS = -Wl,--section-start=.text=0xfc00 -Wl,--section-start=.version=0xfffe
+at90usb647atUART: BOOT_SECTION_SIZE_KIB = 1
 else ## bigboot version is 2048 Bytes long; starts earlier
-at90usb647atUART: LDSECTIONS = -Wl,--section-start=.text=0xf800 -Wl,--section-start=.version=0xfffe
+at90usb647atUART: BOOT_SECTION_SIZE_KIB = 2
 endif
+at90usb647atUART: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
 at90usb647atUART: $(PROGRAM)_at90usb647_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 at90usb647atUART: $(PROGRAM)_at90usb647_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst
@@ -297,11 +318,13 @@ at90usb1286atUART: TARGET = at90usb1286
 at90usb1286atUART: MCU_TARGET = at90usb1286
 at90usb1286atUART: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 at90usb1286atUART: AVR_FREQ ?= 16000000L
+at90usb1286atUART: FLASH_SIZE_KIB = 128
 ifndef BIGBOOT ## standard version is 1024 Bytes long; starts earlier
-at90usb1286atUART: LDSECTIONS = -Wl,--section-start=.text=0x1fc00 -Wl,--section-start=.version=0x1fffe
+at90usb1286atUART: BOOT_SECTION_SIZE_KIB = 1
 else ## bigboot version is 2048 Bytes long; starts earlier
-at90usb1286atUART: LDSECTIONS = -Wl,--section-start=.text=0x1f800 -Wl,--section-start=.version=0x1fffe
+at90usb1286atUART: BOOT_SECTION_SIZE_KIB = 2
 endif
+at90usb1286atUART: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
 at90usb1286atUART: $(PROGRAM)_at90usb1286_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 at90usb1286atUART: $(PROGRAM)_at90usb1286_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst
@@ -331,11 +354,13 @@ at90usb1287atUART: TARGET = at90usb1287
 at90usb1287atUART: MCU_TARGET = at90usb1287
 at90usb1287atUART: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 at90usb1287atUART: AVR_FREQ ?= 16000000L
+at90usb1287atUART: FLASH_SIZE_KIB = 128
 ifndef BIGBOOT ## standard version is 1024 Bytes long; starts earlier
-at90usb1287atUART: LDSECTIONS = -Wl,--section-start=.text=0x1fc00 -Wl,--section-start=.version=0x1fffe
+at90usb1287atUART: BOOT_SECTION_SIZE_KIB = 1
 else ## bigboot version is 2048 Bytes long; starts earlier
-at90usb1287atUART: LDSECTIONS = -Wl,--section-start=.text=0x1f800 -Wl,--section-start=.version=0x1fffe
+at90usb1287atUART: BOOT_SECTION_SIZE_KIB = 2
 endif
+at90usb1287atUART: LDSECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET) -Wl,--section-start=.version=$(VERSION_SEC_OFFSET)
 at90usb1287atUART: $(PROGRAM)_at90usb1287_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).hex
 ifndef PRODUCTION
 at90usb1287atUART: $(PROGRAM)_at90usb1287_UART$(UART)_$(BAUD_RATE)_$(AVR_FREQ)_BB$(BIGBOOT).lst

--- a/optiboot/bootloaders/optiboot/Makefile.usbmcus
+++ b/optiboot/bootloaders/optiboot/Makefile.usbmcus
@@ -17,7 +17,7 @@ HELPTEXT += "target atmega8/16/32u2, atmega16/32u4 - newer 32/44pin AVR-USB-MCUs
 # include file that contains common definitions of variables
 include Makefile.inc
 
-COMMON_SECTIONS = -Wl,--section-start=.text=$(TEXT_SEC_OFFSET)
+
 #-----------------------
 # ATmega 8u2
 #-----------------------

--- a/optiboot/bootloaders/optiboot/Makefile.usbmcus
+++ b/optiboot/bootloaders/optiboot/Makefile.usbmcus
@@ -171,7 +171,6 @@ atmega32u4atUART: MCU_TARGET = atmega32u4
 atmega32u4atUART: CFLAGS += $(COMMON_OPTIONS) $(UART_CMD)
 atmega32u4atUART: AVR_FREQ ?= 16000000L
 atmega32u4atUART: FLASH_SIZE_KIB = 32
-atmega32u4atUART: BOOT_SECTION_SIZE_B = 512
 ifndef BIGBOOT ## standard version is 512 Bytes long; starts earlier
 atmega32u4atUART: BOOT_SECTION_SIZE_B = 512
 else ## bigboot version is 1024 Bytes long; starts earlier

--- a/optiboot/bootloaders/optiboot/makeall.mega0.sh
+++ b/optiboot/bootloaders/optiboot/makeall.mega0.sh
@@ -1,9 +1,8 @@
 # xTiny
-export PACKS=/Downloads/Atmel.ATtiny_DFP.1.3.229
+# change to point to your unpacked attiny packs directory
+export PACKS=/Downloads/Atmel.ATtiny_DFP.1.10.348
 
 make -f Makefile.mega0 version
-
-make -f Makefile.mega0 atmega4809 LED=D6 UARTTX=A0
 
 make -f Makefile.mega0 attiny402 LED=A3 TIMEOUT=8 UARTTX=A1
 make -f Makefile.mega0 attiny412 LED=A3 TIMEOUT=8 UARTTX=A6
@@ -23,7 +22,8 @@ make -f Makefile.mega0 curiosity1607
 make -f Makefile.mega0 xplained416
 
 # Mega0
-export PACKS=/Downloads/Atmel.ATmega_DFP.1.3.300
+# change to point to your unpacked atmega packs directory
+export PACKS=/Downloads/Atmel.ATmega_DFP.1.7.374
 
 make -f Makefile.mega0 version
 


### PR DESCRIPTION
To simplify changes to the location of section I created the file Makefile.inc which contains the formulas to calculate memory sections automatically for all targets.
Besides I fixed some bugs and copy paste errors that stand out.
Finally I compared the output during compilation send to terminal and the hexfiles created for each family on random basis to ensure there are no significant differences.