### PR TITLE
Fix lock fuse verification step in the ISP target

### DIFF
--- a/optiboot/bootloaders/optiboot/Makefile.isp
+++ b/optiboot/bootloaders/optiboot/Makefile.isp
@@ -72,7 +72,7 @@ ISPFUSES =	-e -u -U lock:w:0x$(LOCKFUSE):m $(EFUSE_CMD) \
 # space from accidental SPM writes.  Note: "2f" allows boot section to be read
 # by the application, which is different than the arduino default.
 #
-ISPFLASH =	-U flash:w:$(FILENAME) -U lock:w:$(LOCKFUSE):m
+ISPFLASH =	-U flash:w:$(FILENAME) -U lock:w:0x$(LOCKFUSE):m
 
 # There are certain complicated caused by the fact that the default state
 # of a fuse is a "1" rather than a "0", especially with respect to fuse bits


### PR DESCRIPTION
The fuse bits value has to be prefixed with `0x`, otherwise,
avrdude treats it as a filename and the lock fuse write fails.