### PR TITLE
Implemented load of OSCCAL value (draft)

### DIFF
--- a/optiboot/bootloaders/optiboot/optiboot.c
+++ b/optiboot/bootloaders/optiboot/optiboot.c
@@ -703,8 +703,9 @@ void pre_main(void) {
     "set_osccal:\n" // start_main must difer only by extra 1s, so they can be overwritten to 0s after calibration is done. Here is rjmp is set default to 0x05 and would overwrite to 0x01.
     "  nop\n"
     "  ldi r24, 0xFF\n"
-    "  sts 0x0066, r24\n"
+    "  sts %[osccal_reg], r24\n"
     "start_main:\n"
+    : : [osccal_reg] "M" (_SFR_MEM_ADDR(OSCCAL)) : "r24"
     );
 }
 


### PR DESCRIPTION
Based on discussion with @ondrej-stanek-ozobot , this is attempt at implementing osccal in the bootloader. Would solve issue #87 The idea is originally by @WestfW in https://github.com/Optiboot/optiboot/pull/342#issuecomment-1090918606, this is the implementation i came up with:

 - Any compiled bootloader starts with `rjmp start_main` and `OSCCAL` is not applied (MCU core loads factory default at startup and we don't touch it). This make sure the cpu can start up before the calibration is performed, and for example run a calibration program.
 - rjmp start_main opcode is `0x05 0xc0`, where `0x05` is the offset.
 - when new osccal value is known, the code is patched:
   - `ldi r24,0xFF` instruction is patched to replace `0xFF` with the new osccal value
   - `rjmp start_main` to `rjmp set_osccal`. This can be patched, as set osccal has relative address `0x05` only needs to modify 1s to 0s to become set_osccal `0x01`.
   - from now on, the bootloader jumps to set_osccal before executing main and applies the new `OSCCAL` value
- `ret` and `rjmp` instructions are the same length, so it should work both with `APP_NOSPM` and without. But with `NOSPM`, it's probably necessary to flash it using a programmer, as there is no access to this region from program.
 
Caveats:
 - I'm not sure if the code is stable enough across supported platforms. Specifically, I think there is different STS instruction on avrtiny core that is 1 word instead of 2. But they don't seem to be supported anyway?
 - It wastes 1 word for the `NOP`, as I needed to be able to rewrite the address from `0x05` to `0x01`. Making `sts` and `ldi` combo shorter would also help, the address just needs to be an even number. Or the `rjmp` instruction replaced for a different instruction? Not sure about that.
 - I'm not AVR expert and I probably made a mistake.
 - It does not solve how to put the calibration value into the right place. A separate program needs to handle that.


We will test on our platform and report if it works as expected. For now, we can have a discussion if this approach on the bootloader side is OK-ish and what more needs to be done.

Feel free to discuss, modify and reject if necessary :-)

Edit: formating.