### PR TITLE
Add support for holding a button on boot to wait for programmer.

### DIFF
--- a/optiboot/bootloaders/optiboot/optiboot.c
+++ b/optiboot/bootloaders/optiboot/optiboot.c
@@ -895,6 +895,11 @@ int main(void) {
   #endif
 #endif
 
+#ifdef HOLD_TO_PROG
+  if (HOLD_TO_PROG_ON)
+    watchdogConfig(WATCHDOG_OFF);
+  else
+#endif
   // Set up watchdog to trigger after desired timeout
   watchdogConfig(WDTPERIOD);
 

--- a/optiboot/bootloaders/optiboot/pin_defs.h
+++ b/optiboot/bootloaders/optiboot/pin_defs.h
@@ -1628,3 +1628,26 @@
 #if SOFT_UART && defined(SOFTTX) && defined(SOFTRX)
 #include "pins_softuart.h"
 #endif
+
+#ifdef HOLD_TO_PROG
+
+#if HOLD_TO_PROG == D0
+#undef HOLD_TO_PROG
+#define HOLD_TO_PROG_PIN     PIND
+#define HOLD_TO_PROG	    PIND0
+
+#else
+#error -------------------------------------------
+#error Unrecognized LED name.  Should be like "B5"
+#error -------------------------------------------
+#endif
+
+#endif
+
+#ifdef BUTTON_ON_HIGH
+// A pin is 1 when the button is down
+#define HOLD_TO_PROG_ON ((HOLD_TO_PROG_PIN & HOLD_TO_PROG) == 1)
+#else
+// A pin is 0 when the button is down
+#define HOLD_TO_PROG_ON ((HOLD_TO_PROG_PIN & HOLD_TO_PROG) == 0)
+#endif


### PR DESCRIPTION
Not sure if this would be useful to other people, but at least the PR can be searched for. Trying to upload to a cricut via PIO or arduino, I kept hitting timeouts, so I added a def for a button which, if held down, causes it to wait forever for programming. The cricut has buttons low when on, but both are supported.

If it's useful, I could probably create #ifdef blocks for the other pins/ports.