### PR TITLE
Add support for $EXTRA_CFLAGS.

### DIFF
--- a/optiboot/bootloaders/optiboot/Makefile
+++ b/optiboot/bootloaders/optiboot/Makefile
@@ -300,6 +300,7 @@ COMMON_OPTIONS += $(SOFT_UART_CMD) $(LED_DATA_FLASH_CMD) $(LED_CMD) $(SS_CMD)
 COMMON_OPTIONS += $(SUPPORT_EEPROM_CMD) $(LED_START_ON_CMD) $(APPSPM_CMD)
 COMMON_OPTIONS += $(OSCCAL_VALUE_CMD) $(VERSION_CMD) $(TIMEOUT_CMD)
 COMMON_OPTIONS += $(POR_CMD) $(EXTR_CMD) $(RS485_CMD)
+COMMON_OPTIONS += $(EXTRA_CFLAGS)
 
 #UART is handled separately and only passed for devices with more than one.
 HELPTEXT += "Option UART=n                - use UARTn for communications\n"


### PR DESCRIPTION
This allows the user to add extra CFLAGS without modifying the Makefile.

For example:
```bash
ATMEGA_SUPPORT_PACK="$HOME/src/Atmel.ATmega_DFP.2.1.506"
EXTRA_CFLAGS="-B $ATMEGA_SUPPORT_PACK/gcc/dev/atmega328pb"
EXTRA_CFLAGS+=" -I$ATMEGA_SUPPORT_PACK/include"
make EXTRA_CFLAGS="$EXTRA_CFLAGS" atmega328pb AVR_FREQ=16000000L BAUD_RATE=115200 LED=B5 LED_START_FLASHES=0 UART=0
```